### PR TITLE
Revert "ci: on-demand install of mise tools"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
       - *checkout
       - *setup-go
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
-        with:
-          install: false
       - name: Test
         run: mise test
       - name: Test Integration


### PR DESCRIPTION
This reverts commit df953970386049aada46efeb585e0ac84b14b46c.