### PR TITLE
period stats+fable review

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ repeat = "3s"
 port = 8080
 retention = "10080m"
 reports = ["10s", "15m", "60m", "1440m", "10080m"]
+
+# Optional: probe-stat bucket granularity per report period.
+# Each report period is split into at least `min` buckets (default 100),
+# and a single bucket never aggregates more than `maxSpan` (default 30m).
+[stats.buckets]
+min = 100
+maxSpan = "30m"
 ```
 
 ## Status

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -3,6 +3,7 @@ package check
 
 import (
 	"context"
+	"iter"
 	"time"
 )
 
@@ -80,27 +81,13 @@ func (c *Check) RunProbe(ctx context.Context, checker Checker) *Report {
 // Example:
 //
 //	checker := &LoggingChecker{}
-//	success, err := check.CheckerRun(ctx, checker, checkList.GetIterator())
-//
-// Parameters:
-//   - ctx: Context for cancellation and timeout control
-//   - checker: Implementation of Checker interface for lifecycle callbacks
-//   - checkListIterator: Iterator over checks to execute
-//
-// Returns:
-//   - bool: true if any check succeeded, false if all failed
-//   - error: any error that occurred during iteration (not individual probe failures)
+//	success := check.CheckerRun(ctx, checker, checkList.All())
 func CheckerRun(
 	ctx context.Context,
 	checker Checker,
-	checkListIterator ListIterator,
-) (bool, error) {
-	for {
-		check := checkListIterator.Fetch()
-		if check == nil {
-			return false, nil // All checks failed
-		}
-
+	checks iter.Seq[*Check],
+) bool {
+	for check := range checks {
 		report := check.RunProbe(ctx, checker)
 		if report.error != nil {
 			checker.ProbeFailure(report)
@@ -110,6 +97,8 @@ func CheckerRun(
 
 		checker.ProbeSuccess(report)
 
-		return true, nil
+		return true
 	}
+
+	return false // All checks failed
 }

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -18,6 +18,7 @@ func (f *fakeProbe) Execute(_ context.Context, _ time.Duration) *Report {
 	return f.ret
 }
 func (*fakeProbe) Scheme() string { return "fake" }
+func (*fakeProbe) Target() string { return "fake" }
 
 type fakeListIterator struct {
 	checks []*Check

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -3,11 +3,11 @@ package check
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type fakeProbe struct {
@@ -19,22 +19,6 @@ func (f *fakeProbe) Execute(_ context.Context, _ time.Duration) *Report {
 }
 func (*fakeProbe) Scheme() string { return "fake" }
 func (*fakeProbe) Target() string { return "fake" }
-
-type fakeListIterator struct {
-	checks []*Check
-	idx    int
-}
-
-func (it *fakeListIterator) Fetch() *Check {
-	if it.idx >= len(it.checks) {
-		return nil
-	}
-
-	c := it.checks[it.idx]
-	it.idx++
-
-	return c
-}
 
 type recordChecker struct {
 	run  []Check
@@ -50,12 +34,9 @@ func TestCheckerRun_SuccessFirst(t *testing.T) {
 	probe := &fakeProbe{ret: &Report{}}
 	probeIface := Probe(probe)
 	check := &Check{Probe: probeIface, Timeout: 1 * time.Second}
-	it := &fakeListIterator{checks: []*Check{check}}
 	checker := &recordChecker{}
-	ctx := t.Context()
-	ok, err := CheckerRun(ctx, checker, it)
+	ok := CheckerRun(t.Context(), checker, slices.Values([]*Check{check}))
 	assert.True(t, ok)
-	require.NoError(t, err)
 	assert.Len(t, checker.run, 1)
 	assert.Len(t, checker.succ, 1)
 	assert.Empty(t, checker.fail)
@@ -66,40 +47,31 @@ func TestCheckerRun_AllFail(t *testing.T) {
 	probe := &fakeProbe{ret: rep}
 	probeIface := Probe(probe)
 	check := &Check{Probe: probeIface, Timeout: 1 * time.Second}
-	it := &fakeListIterator{checks: []*Check{check, check}}
 	checker := &recordChecker{}
-	ctx := t.Context()
-	ok, err := CheckerRun(ctx, checker, it)
+	ok := CheckerRun(t.Context(), checker, slices.Values([]*Check{check, check}))
 	assert.False(t, ok)
-	require.NoError(t, err)
 	assert.Len(t, checker.run, 2)
 	assert.Empty(t, checker.succ)
 	assert.Len(t, checker.fail, 2)
 }
 
 func TestCheckerRun_Empty(t *testing.T) {
-	it := &fakeListIterator{checks: []*Check{}}
 	checker := &recordChecker{}
-	ctx := t.Context()
-	ok, err := CheckerRun(ctx, checker, it)
+	ok := CheckerRun(t.Context(), checker, slices.Values([]*Check{}))
 	assert.False(t, ok)
-	require.NoError(t, err)
 	assert.Empty(t, checker.run)
 	assert.Empty(t, checker.succ)
 	assert.Empty(t, checker.fail)
 }
 
-func TestCheckerRun_WithListIterator(t *testing.T) {
+func TestCheckerRun_WithList(t *testing.T) {
 	probe := &fakeProbe{ret: &Report{}}
 	probeIface := Probe(probe)
 	check := &Check{Probe: probeIface, Timeout: 1 * time.Second}
 	cl := &List{Ordered: Checks{check}}
-	it := cl.GetIterator()
 	checker := &recordChecker{}
-	ctx := t.Context()
-	ok, err := CheckerRun(ctx, checker, it)
+	ok := CheckerRun(t.Context(), checker, cl.All())
 	assert.True(t, ok)
-	require.NoError(t, err)
 	assert.Len(t, checker.run, 1)
 	assert.Len(t, checker.succ, 1)
 	assert.Empty(t, checker.fail)

--- a/internal/check/checklist.go
+++ b/internal/check/checklist.go
@@ -1,22 +1,12 @@
 package check
 
-import "math/rand/v2"
+import (
+	"iter"
+	"math/rand/v2"
+)
 
 // Checks is a collection of check definitions.
 type Checks []*Check
-
-// ChecksIterator provides sequential access to a Checks collection.
-type ChecksIterator interface {
-	Fetch() *Check
-	ShuffleIfNeeded()
-}
-
-// ChecksIteratorImpl implements ChecksIterator with index-based iteration.
-type ChecksIteratorImpl struct {
-	checks Checks
-	index  int
-	limit  int
-}
 
 // List contains ordered and shuffled check collections.
 type List struct {
@@ -24,77 +14,21 @@ type List struct {
 	Shuffled Checks
 }
 
-// ListIterator provides sequential access to both ordered and shuffled checks.
-type ListIterator interface {
-	Fetch() *Check
-}
+// All returns an iterator over all checks: the ordered ones first, then the
+// shuffled ones in a fresh random order. The permutation is only computed if
+// iteration reaches the shuffled section.
+func (cl *List) All() iter.Seq[*Check] {
+	return func(yield func(*Check) bool) {
+		for _, c := range cl.Ordered {
+			if !yield(c) {
+				return
+			}
+		}
 
-// ListIteratorImpl implements ListIterator for ordered then shuffled access.
-type ListIteratorImpl struct {
-	orderedIterator  ChecksIterator
-	shuffledIterator ChecksIterator
-}
-
-// NewChecksIterator creates a new iterator for the given checks.
-func NewChecksIterator(checks Checks) *ChecksIteratorImpl {
-	return &ChecksIteratorImpl{
-		checks: checks,
-		index:  0,
-		limit:  len(checks),
+		for _, i := range rand.Perm(len(cl.Shuffled)) {
+			if !yield(cl.Shuffled[i]) {
+				return
+			}
+		}
 	}
-}
-
-// Shuffle randomizes the order of checks in place.
-func (checks Checks) Shuffle() {
-	rand.Shuffle(len(checks), func(i, j int) {
-		checks[i], checks[j] = checks[j], checks[i]
-	})
-}
-
-// ShuffleIfNeeded shuffles the checks on first iteration only.
-func (it *ChecksIteratorImpl) ShuffleIfNeeded() {
-	if it.index > 0 {
-		return
-	}
-
-	it.checks.Shuffle()
-}
-
-// Fetch returns the next check or nil if exhausted.
-func (it *ChecksIteratorImpl) Fetch() *Check {
-	if it.index < it.limit {
-		check := it.checks[it.index]
-		it.index++
-
-		return check
-	}
-
-	return nil
-}
-
-// GetIterator creates a new iterator over both ordered and shuffled checks.
-func (cl *List) GetIterator() *ListIteratorImpl {
-	return &ListIteratorImpl{
-		orderedIterator:  NewChecksIterator(cl.Ordered),
-		shuffledIterator: NewChecksIterator(cl.Shuffled),
-	}
-}
-
-// Fetch returns the next check from ordered then shuffled lists.
-func (it *ListIteratorImpl) Fetch() *Check {
-	var check *Check
-
-	check = it.orderedIterator.Fetch()
-	if check != nil {
-		return check
-	}
-
-	it.shuffledIterator.ShuffleIfNeeded()
-
-	check = it.shuffledIterator.Fetch()
-	if check != nil {
-		return check
-	}
-
-	return nil
 }

--- a/internal/check/checklist_test.go
+++ b/internal/check/checklist_test.go
@@ -48,9 +48,9 @@ func TestListAll_DoesNotMutateShuffled(t *testing.T) {
 	orig := slices.Clone(shuffled)
 	cl := &List{Shuffled: shuffled}
 
-	for range cl.All() {
-	}
+	got := slices.Collect(cl.All())
 
+	assert.Len(t, got, len(orig))
 	assert.True(t, slices.Equal(orig, shuffled), "All() should not reorder the underlying slice")
 }
 

--- a/internal/check/checklist_test.go
+++ b/internal/check/checklist_test.go
@@ -9,75 +9,49 @@ import (
 )
 
 func newCheck(_ int) *Check {
-	// Replace with actual Check struct if needed
 	return &Check{}
 }
 
-func TestChecksIterator_Fetch(t *testing.T) {
-	checks := Checks{newCheck(1), newCheck(2), newCheck(3)}
-	it := NewChecksIterator(checks)
-
-	for i := range checks {
-		got := it.Fetch()
-		assert.NotNil(t, got, "Fetch() = nil at index %d, want check", i)
-	}
-
-	assert.Nil(t, it.Fetch(), "Fetch() after end should return nil")
-}
-
-func TestChecksIterator_ShuffleIfNeeded(t *testing.T) {
-	orig := Checks{newCheck(1), newCheck(2), newCheck(3), newCheck(4)}
-	checks := slices.Clone(orig)
-	it := NewChecksIterator(checks)
-
-	// Should shuffle since index == 0
-	it.ShuffleIfNeeded()
-	// Can't guarantee shuffle, but can check that it's still a permutation
-	assert.True(t, sameElements(checks, orig), "Shuffled checks lost elements")
-
-	// Should NOT shuffle since index > 0
-	it.index = 1
-	before := slices.Clone(checks)
-
-	it.ShuffleIfNeeded()
-	assert.True(t, slices.Equal(before, checks), "ShuffleIfNeeded shuffled when index > 0")
-}
-
-func TestChecks_Shuffle(t *testing.T) {
-	orig := Checks{newCheck(1), newCheck(2), newCheck(3), newCheck(4)}
-	checks := slices.Clone(orig)
-	checks.Shuffle()
-	assert.True(t, sameElements(checks, orig), "Shuffle lost elements")
-	// Not guaranteed to change order, but likely
-}
-
-func TestListIterator_Fetch(t *testing.T) {
+func TestListAll_OrderedFirst(t *testing.T) {
 	ordered := Checks{newCheck(1), newCheck(2)}
 	shuffled := Checks{newCheck(3), newCheck(4)}
 	cl := &List{Ordered: ordered, Shuffled: shuffled}
-	it := cl.GetIterator()
 
-	var got []*Check
+	got := slices.Collect(cl.All())
 
-	for {
-		c := it.Fetch()
-		if c == nil {
-			break
-		}
-
-		got = append(got, c)
-	}
-
-	assert.Len(t, got, 4, "Fetch() got %d checks, want 4", len(got))
-
+	assert.Len(t, got, 4)
 	assert.Same(t, got[0], ordered[0], "first check should be from ordered")
 	assert.Same(t, got[1], ordered[1], "second check should be from ordered")
+	assert.True(t, sameElements(got[2:], shuffled), "shuffled checks lost elements")
 }
 
-func TestListIterator_Empty(t *testing.T) {
+func TestListAll_Empty(t *testing.T) {
 	cl := &List{}
-	it := cl.GetIterator()
-	assert.Nil(t, it.Fetch(), "Fetch() on empty iterator should return nil")
+	assert.Empty(t, slices.Collect(cl.All()))
+}
+
+func TestListAll_EarlyBreak(t *testing.T) {
+	cl := &List{Ordered: Checks{newCheck(1), newCheck(2)}}
+
+	count := 0
+	for range cl.All() {
+		count++
+
+		break
+	}
+
+	assert.Equal(t, 1, count)
+}
+
+func TestListAll_DoesNotMutateShuffled(t *testing.T) {
+	shuffled := Checks{newCheck(1), newCheck(2), newCheck(3), newCheck(4)}
+	orig := slices.Clone(shuffled)
+	cl := &List{Shuffled: shuffled}
+
+	for range cl.All() {
+	}
+
+	assert.True(t, slices.Equal(orig, shuffled), "All() should not reorder the underlying slice")
 }
 
 // Helper: check if two slices have the same elements (ignoring order).

--- a/internal/check/probe.go
+++ b/internal/check/probe.go
@@ -31,4 +31,6 @@ type Probe interface {
 	//
 	// Example: "http", "https", "tcp", "dns"
 	Scheme() string
+
+	Target() string
 }

--- a/internal/check/probe_dns.go
+++ b/internal/check/probe_dns.go
@@ -58,6 +58,11 @@ func (DNSProbe) Scheme() string {
 	return DNS
 }
 
+// Target returns the DNS resolver address being probed.
+func (p DNSProbe) Target() string {
+	return p.DNSResolver
+}
+
 // Execute runs the DNS resolution and returns a report.
 func (p DNSProbe) Execute(ctx context.Context, timeout time.Duration) *Report {
 	resolver := p.resolver

--- a/internal/check/probe_dns.go
+++ b/internal/check/probe_dns.go
@@ -65,14 +65,15 @@ func (p DNSProbe) Target() string {
 
 // Execute runs the DNS resolution and returns a report.
 func (p DNSProbe) Execute(ctx context.Context, timeout time.Duration) *Report {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	resolver := p.resolver
 	if resolver == nil {
 		resolver = &net.Resolver{
 			PreferGo: true,
 			Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
-				d := net.Dialer{
-					Timeout: timeout,
-				}
+				var d net.Dialer
 
 				return d.DialContext(ctx, network, p.DNSResolver)
 			},
@@ -80,7 +81,7 @@ func (p DNSProbe) Execute(ctx context.Context, timeout time.Duration) *Report {
 	}
 
 	start := time.Now()
-	addr, err := resolver.LookupHost(ctx, p.Domain)
+	addr, err := resolver.LookupHost(ctxWithTimeout, p.Domain)
 
 	report := BuildReport(p, start)
 	if err != nil {

--- a/internal/check/probe_dns_test.go
+++ b/internal/check/probe_dns_test.go
@@ -77,6 +77,18 @@ func TestNewDNSProbe_Error(t *testing.T) {
 	}
 }
 
+func TestDnsProbe_Target(t *testing.T) {
+	probe, err := NewDNSProbe("1.1.1.1", "example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "1.1.1.1:53", probe.Target())
+}
+
+func TestDnsProbe_WithPort_Target(t *testing.T) {
+	probe, err := NewDNSProbe("8.8.8.8:5353", "example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "8.8.8.8:5353", probe.Target())
+}
+
 func TestDnsProbe(t *testing.T) {
 	t.Run("returns the first resolved IP address if the request is successful", func(t *testing.T) {
 		resolver := &fakeResolver{result: []string{"1.2.3.4"}}

--- a/internal/check/probe_http.go
+++ b/internal/check/probe_http.go
@@ -1,10 +1,12 @@
 package check
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/hugoh/upd/internal/version"
@@ -29,17 +31,23 @@ var updClient = &http.Client{}
 // HTTPProbe performs HTTP connectivity checks.
 type HTTPProbe struct {
 	URL    string
+	scheme string
 	client *http.Client
 }
 
 // NewHTTPProbe creates a new HTTP probe for the given URL.
 func NewHTTPProbe(url string) *HTTPProbe {
-	return &HTTPProbe{URL: url, client: updClient}
+	scheme := HTTP
+	if strings.HasPrefix(url, HTTPS+":") {
+		scheme = HTTPS
+	}
+
+	return &HTTPProbe{URL: url, scheme: scheme, client: updClient}
 }
 
 // Scheme returns the protocol scheme (http or https).
-func (*HTTPProbe) Scheme() string {
-	return HTTP
+func (p *HTTPProbe) Scheme() string {
+	return cmp.Or(p.scheme, HTTP)
 }
 
 // Target returns the URL being probed.

--- a/internal/check/probe_http.go
+++ b/internal/check/probe_http.go
@@ -54,6 +54,11 @@ func (*HTTPProbe) Scheme() string {
 	return HTTP
 }
 
+// Target returns the URL being probed.
+func (p *HTTPProbe) Target() string {
+	return p.URL
+}
+
 // Execute runs the HTTP request and returns a report.
 func (p *HTTPProbe) Execute(ctx context.Context, timeout time.Duration) *Report {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)

--- a/internal/check/probe_http.go
+++ b/internal/check/probe_http.go
@@ -3,6 +3,7 @@ package check
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -12,31 +13,18 @@ import (
 const (
 	// UserAgentPrefix is prepended to the version in the User-Agent header.
 	UserAgentPrefix = "upd/"
+
+	// maxBodyDrain caps how much of the response body is read before closing
+	// so the pooled connection can be reused without downloading arbitrarily
+	// large bodies.
+	maxBodyDrain = 4096
 )
 
 // updClient is a shared HTTP client for all HTTP probes.
 // Using a single client enables connection pooling and improves performance.
 //
 //nolint:gochecknoglobals // Intentional singleton for connection pooling
-var updClient = &http.Client{
-	Transport: &updTransport{version: version.Version()},
-}
-
-type updTransport struct {
-	version  string
-	delegate http.RoundTripper
-}
-
-func (t *updTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add("User-Agent", UserAgentPrefix+t.version)
-
-	d := t.delegate
-	if d == nil {
-		d = http.DefaultTransport
-	}
-
-	return d.RoundTrip(req) //nolint:wrapcheck // base transport
-}
+var updClient = &http.Client{}
 
 // HTTPProbe performs HTTP connectivity checks.
 type HTTPProbe struct {
@@ -73,6 +61,8 @@ func (p *HTTPProbe) Execute(ctx context.Context, timeout time.Duration) *Report 
 		return report
 	}
 
+	req.Header.Set("User-Agent", UserAgentPrefix+version.Version())
+
 	start := time.Now()
 	resp, err := p.client.Do(req)
 
@@ -88,6 +78,9 @@ func (p *HTTPProbe) Execute(ctx context.Context, timeout time.Duration) *Report 
 			report.error = fmt.Errorf("error closing response body: %w", closeErr)
 		}
 	}()
+
+	// Drain (bounded) so the pooled connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxBodyDrain))
 
 	report.response = resp.Status
 

--- a/internal/check/probe_http_test.go
+++ b/internal/check/probe_http_test.go
@@ -120,7 +120,7 @@ func TestHTTPProbe_RoundTrip(t *testing.T) {
 			gotUA = req.Header.Get("User-Agent")
 		},
 	}
-	trans := &updTransport{version: "test", delegate: ft}
+	trans := &updTransport{version: "ver", delegate: ft}
 	req := httptest.NewRequest(http.MethodGet, testURL+"/rt", http.NoBody)
 	resp, err := trans.RoundTrip(req)
 	require.NoError(t, err)
@@ -128,12 +128,12 @@ func TestHTTPProbe_RoundTrip(t *testing.T) {
 
 	_ = resp.Body.Close()
 
-	assert.Equal(t, "upd/test", gotUA)
+	assert.Equal(t, "upd/ver", gotUA)
 }
 
 func TestHTTPProbe_RoundTrip_NetworkFailure(t *testing.T) {
 	trans := &updTransport{
-		version:  "test",
+		version:  "e2e",
 		delegate: &fakeRoundTripper{err: errors.New("connection refused")},
 	}
 	req := httptest.NewRequest(http.MethodGet, testURL+"/test", http.NoBody)
@@ -152,6 +152,11 @@ func TestHTTPProbe_ProbeWithTimeout(t *testing.T) {
 	report := httpProbe.Execute(t.Context(), time.Second)
 	require.Error(t, report.error)
 	assert.Contains(t, report.error.Error(), "error building request")
+}
+
+func TestHTTPProbe_Target(t *testing.T) {
+	probe := NewHTTPProbe("http://example.com/path")
+	assert.Equal(t, "http://example.com/path", probe.Target())
 }
 
 func TestHTTPProbe_Scheme(t *testing.T) {

--- a/internal/check/probe_http_test.go
+++ b/internal/check/probe_http_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -53,17 +52,14 @@ func TestHttpProbe_UserAgentHeader(t *testing.T) {
 	probe := &HTTPProbe{
 		URL: "http://example.com/ua",
 		client: &http.Client{
-			Transport: &updTransport{
-				version: "dev",
-				delegate: &fakeRoundTripper{
-					resp: &http.Response{
-						StatusCode: http.StatusOK,
-						Status:     testOKStatus,
-						Body:       io.NopCloser(strings.NewReader("pong")),
-					},
-					checkReq: func(req *http.Request) {
-						gotUA = req.Header.Get("User-Agent")
-					},
+			Transport: &fakeRoundTripper{
+				resp: &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     testOKStatus,
+					Body:       io.NopCloser(strings.NewReader("pong")),
+				},
+				checkReq: func(req *http.Request) {
+					gotUA = req.Header.Get("User-Agent")
 				},
 			},
 		},
@@ -72,6 +68,26 @@ func TestHttpProbe_UserAgentHeader(t *testing.T) {
 	report := probe.Execute(t.Context(), testTimeout)
 	require.NoError(t, report.error)
 	assert.Equal(t, "upd/dev", gotUA)
+}
+
+func TestHttpProbe_DrainsBodyForConnectionReuse(t *testing.T) {
+	body := strings.NewReader(strings.Repeat("x", 1024))
+	probe := &HTTPProbe{
+		URL: testURL,
+		client: &http.Client{
+			Transport: &fakeRoundTripper{
+				resp: &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     testOKStatus,
+					Body:       io.NopCloser(body),
+				},
+			},
+		},
+	}
+
+	report := probe.Execute(t.Context(), testTimeout)
+	require.NoError(t, report.error)
+	assert.Zero(t, body.Len(), "response body should be drained")
 }
 
 func TestHttpProbe_RequestFails(t *testing.T) {
@@ -105,46 +121,6 @@ func TestHttpProbe_Timeout(t *testing.T) {
 
 	report := probe.Execute(t.Context(), testTimeout)
 	checkTimeout(t, report, "context deadline exceeded")
-}
-
-func TestHTTPProbe_RoundTrip(t *testing.T) {
-	var gotUA string
-
-	ft := &fakeRoundTripper{
-		resp: &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     testOKStatus,
-			Body:       io.NopCloser(strings.NewReader("ok")),
-		},
-		checkReq: func(req *http.Request) {
-			gotUA = req.Header.Get("User-Agent")
-		},
-	}
-	trans := &updTransport{version: "ver", delegate: ft}
-	req := httptest.NewRequest(http.MethodGet, testURL+"/rt", http.NoBody)
-	resp, err := trans.RoundTrip(req)
-	require.NoError(t, err)
-	assert.Equal(t, 200, resp.StatusCode)
-
-	_ = resp.Body.Close()
-
-	assert.Equal(t, "upd/ver", gotUA)
-}
-
-func TestHTTPProbe_RoundTrip_NetworkFailure(t *testing.T) {
-	trans := &updTransport{
-		version:  "e2e",
-		delegate: &fakeRoundTripper{err: errors.New("connection refused")},
-	}
-	req := httptest.NewRequest(http.MethodGet, testURL+"/test", http.NoBody)
-
-	resp, err := trans.RoundTrip(req)
-
-	if resp != nil {
-		_ = resp.Body.Close()
-	}
-
-	assert.Error(t, err)
 }
 
 func TestHTTPProbe_ProbeWithTimeout(t *testing.T) {

--- a/internal/check/probe_http_test.go
+++ b/internal/check/probe_http_test.go
@@ -139,3 +139,8 @@ func TestHTTPProbe_Scheme(t *testing.T) {
 	probe := NewHTTPProbe("http://example.com")
 	assert.Equal(t, "http", probe.Scheme())
 }
+
+func TestHTTPProbe_SchemeHTTPS(t *testing.T) {
+	probe := NewHTTPProbe("https://example.com")
+	assert.Equal(t, "https", probe.Scheme())
+}

--- a/internal/check/probe_tcp.go
+++ b/internal/check/probe_tcp.go
@@ -28,6 +28,11 @@ func (TCPProbe) Scheme() string {
 	return TCP
 }
 
+// Target returns the host:port being probed.
+func (p TCPProbe) Target() string {
+	return p.HostPort
+}
+
 // Execute runs the TCP connection attempt and returns a report.
 func (p TCPProbe) Execute(ctx context.Context, timeout time.Duration) *Report {
 	start := time.Now()

--- a/internal/check/probe_tcp_test.go
+++ b/internal/check/probe_tcp_test.go
@@ -32,6 +32,11 @@ type stubTCPConn struct {
 
 func (c *stubTCPConn) LocalAddr() net.Addr { return c.localAddr }
 
+func TestTcpProbe_Target(t *testing.T) {
+	probe := NewTCPProbe("192.168.1.1:8080")
+	assert.Equal(t, "192.168.1.1:8080", probe.Target())
+}
+
 func TestTcpProbe_Success(t *testing.T) {
 	wantLocalAddr := &fakeTCPAddr{addr: "127.0.0.1:54321"}
 	_, clientEnd := net.Pipe()

--- a/internal/check/report.go
+++ b/internal/check/report.go
@@ -13,20 +13,18 @@ import (
 //
 // Only one of the properties 'Response' or 'Error' is set.
 type Report struct {
-	// protocol used to connect to.
 	protocol string
-	// Target used to connect to.
+	target   string
 	response string
-	// Response time.
-	elapsed time.Duration
-	// Network error.
-	error error
+	elapsed  time.Duration
+	error    error
 }
 
 // BuildReport creates a new report for the given probe.
 func BuildReport(p Probe, startTime time.Time) *Report {
 	return &Report{
 		protocol: p.Scheme(),
+		target:   p.Target(),
 		elapsed:  time.Since(startTime),
 	}
 }
@@ -35,6 +33,7 @@ func BuildReport(p Probe, startTime time.Time) *Report {
 func (r *Report) LogAttrs() slog.Attr {
 	attrs := []any{
 		slog.String("protocol", r.protocol),
+		slog.String("target", r.target),
 		slog.Duration("elapsed", r.elapsed),
 	}
 	if r.response != "" {

--- a/internal/check/report_test.go
+++ b/internal/check/report_test.go
@@ -2,74 +2,85 @@ package check
 
 import (
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLogAttrs_Response(t *testing.T) {
-	report := &Report{
-		protocol: HTTP,
-		target:   "http://example.com",
-		response: "OK",
-		elapsed:  123 * time.Millisecond,
+//nolint:funlen // table-driven test with inline struct/closure literals
+func TestLogAttrs(t *testing.T) {
+	netErr := errors.New("network error")
+
+	tests := []struct {
+		name     string
+		report   *Report
+		wantLen  int
+		extraKey string
+		checkFn  func(t *testing.T, v slog.Value)
+	}{
+		{
+			name: "response",
+			report: &Report{
+				protocol: HTTP,
+				target:   "http://example.com",
+				response: "OK",
+				elapsed:  123 * time.Millisecond,
+			},
+			wantLen:  4,
+			extraKey: "response",
+			checkFn: func(t *testing.T, v slog.Value) {
+				t.Helper()
+				assert.Equal(t, "OK", v.String())
+			},
+		},
+		{
+			name: "error",
+			report: &Report{
+				protocol: "tcp",
+				target:   "127.0.0.1:80",
+				elapsed:  456 * time.Millisecond,
+				error:    netErr,
+			},
+			wantLen:  4,
+			extraKey: "error",
+			checkFn: func(t *testing.T, v slog.Value) {
+				t.Helper()
+				assert.Equal(t, netErr, v.Any())
+			},
+		},
+		{
+			name: "neither response nor error",
+			report: &Report{
+				protocol: "udp",
+				target:   "192.168.1.1:53",
+				elapsed:  789 * time.Millisecond,
+			},
+			wantLen: 3,
+		},
 	}
-	attr := report.LogAttrs()
 
-	assert.Equal(t, "report", attr.Key)
-	group := attr.Value.Group()
-	assert.Len(t, group, 4)
-	assert.Equal(t, "protocol", group[0].Key)
-	assert.Equal(t, "http", group[0].Value.String())
-	assert.Equal(t, "target", group[1].Key)
-	assert.Equal(t, "http://example.com", group[1].Value.String())
-	assert.Equal(t, "elapsed", group[2].Key)
-	assert.Equal(t, 123*time.Millisecond, group[2].Value.Duration())
-	assert.Equal(t, "response", group[3].Key)
-	assert.Equal(t, "OK", group[3].Value.String())
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := tt.report.LogAttrs()
 
-func TestLogAttrs_Error(t *testing.T) {
-	err := errors.New("network error")
-	report := &Report{
-		protocol: "tcp",
-		target:   "127.0.0.1:80",
-		elapsed:  456 * time.Millisecond,
-		error:    err,
+			assert.Equal(t, "report", attr.Key)
+			group := attr.Value.Group()
+			assert.Len(t, group, tt.wantLen)
+			assert.Equal(t, "protocol", group[0].Key)
+			assert.Equal(t, tt.report.protocol, group[0].Value.String())
+			assert.Equal(t, "target", group[1].Key)
+			assert.Equal(t, tt.report.target, group[1].Value.String())
+			assert.Equal(t, "elapsed", group[2].Key)
+			assert.Equal(t, tt.report.elapsed, group[2].Value.Duration())
+
+			if tt.checkFn != nil {
+				assert.Equal(t, tt.extraKey, group[3].Key)
+				tt.checkFn(t, group[3].Value)
+			}
+		})
 	}
-	attr := report.LogAttrs()
-
-	assert.Equal(t, "report", attr.Key)
-	group := attr.Value.Group()
-	assert.Len(t, group, 4)
-	assert.Equal(t, "protocol", group[0].Key)
-	assert.Equal(t, "tcp", group[0].Value.String())
-	assert.Equal(t, "target", group[1].Key)
-	assert.Equal(t, "127.0.0.1:80", group[1].Value.String())
-	assert.Equal(t, "elapsed", group[2].Key)
-	assert.Equal(t, 456*time.Millisecond, group[2].Value.Duration())
-	assert.Equal(t, "error", group[3].Key)
-	assert.Equal(t, err, group[3].Value.Any())
-}
-
-func TestLogAttrs_Empty(t *testing.T) {
-	report := &Report{
-		protocol: "udp",
-		target:   "192.168.1.1:53",
-		elapsed:  789 * time.Millisecond,
-	}
-	attr := report.LogAttrs()
-
-	assert.Equal(t, "report", attr.Key)
-	group := attr.Value.Group()
-	assert.Len(t, group, 3)
-	assert.Equal(t, "protocol", group[0].Key)
-	assert.Equal(t, "udp", group[0].Value.String())
-	assert.Equal(t, "target", group[1].Key)
-	assert.Equal(t, "192.168.1.1:53", group[1].Value.String())
-	assert.Equal(t, "elapsed", group[2].Key)
-	assert.Equal(t, 789*time.Millisecond, group[2].Value.Duration())
 }
 
 func TestProtocol(t *testing.T) {

--- a/internal/check/report_test.go
+++ b/internal/check/report_test.go
@@ -11,6 +11,7 @@ import (
 func TestLogAttrs_Response(t *testing.T) {
 	report := &Report{
 		protocol: HTTP,
+		target:   "http://example.com",
 		response: "OK",
 		elapsed:  123 * time.Millisecond,
 	}
@@ -18,19 +19,22 @@ func TestLogAttrs_Response(t *testing.T) {
 
 	assert.Equal(t, "report", attr.Key)
 	group := attr.Value.Group()
-	assert.Len(t, group, 3)
+	assert.Len(t, group, 4)
 	assert.Equal(t, "protocol", group[0].Key)
 	assert.Equal(t, "http", group[0].Value.String())
-	assert.Equal(t, "elapsed", group[1].Key)
-	assert.Equal(t, 123*time.Millisecond, group[1].Value.Duration())
-	assert.Equal(t, "response", group[2].Key)
-	assert.Equal(t, "OK", group[2].Value.String())
+	assert.Equal(t, "target", group[1].Key)
+	assert.Equal(t, "http://example.com", group[1].Value.String())
+	assert.Equal(t, "elapsed", group[2].Key)
+	assert.Equal(t, 123*time.Millisecond, group[2].Value.Duration())
+	assert.Equal(t, "response", group[3].Key)
+	assert.Equal(t, "OK", group[3].Value.String())
 }
 
 func TestLogAttrs_Error(t *testing.T) {
 	err := errors.New("network error")
 	report := &Report{
 		protocol: "tcp",
+		target:   "127.0.0.1:80",
 		elapsed:  456 * time.Millisecond,
 		error:    err,
 	}
@@ -38,29 +42,34 @@ func TestLogAttrs_Error(t *testing.T) {
 
 	assert.Equal(t, "report", attr.Key)
 	group := attr.Value.Group()
-	assert.Len(t, group, 3)
+	assert.Len(t, group, 4)
 	assert.Equal(t, "protocol", group[0].Key)
 	assert.Equal(t, "tcp", group[0].Value.String())
-	assert.Equal(t, "elapsed", group[1].Key)
-	assert.Equal(t, 456*time.Millisecond, group[1].Value.Duration())
-	assert.Equal(t, "error", group[2].Key)
-	assert.Equal(t, err, group[2].Value.Any())
+	assert.Equal(t, "target", group[1].Key)
+	assert.Equal(t, "127.0.0.1:80", group[1].Value.String())
+	assert.Equal(t, "elapsed", group[2].Key)
+	assert.Equal(t, 456*time.Millisecond, group[2].Value.Duration())
+	assert.Equal(t, "error", group[3].Key)
+	assert.Equal(t, err, group[3].Value.Any())
 }
 
 func TestLogAttrs_Empty(t *testing.T) {
 	report := &Report{
 		protocol: "udp",
+		target:   "192.168.1.1:53",
 		elapsed:  789 * time.Millisecond,
 	}
 	attr := report.LogAttrs()
 
 	assert.Equal(t, "report", attr.Key)
 	group := attr.Value.Group()
-	assert.Len(t, group, 2)
+	assert.Len(t, group, 3)
 	assert.Equal(t, "protocol", group[0].Key)
 	assert.Equal(t, "udp", group[0].Value.String())
-	assert.Equal(t, "elapsed", group[1].Key)
-	assert.Equal(t, 789*time.Millisecond, group[1].Value.Duration())
+	assert.Equal(t, "target", group[1].Key)
+	assert.Equal(t, "192.168.1.1:53", group[1].Value.String())
+	assert.Equal(t, "elapsed", group[2].Key)
+	assert.Equal(t, 789*time.Millisecond, group[2].Value.Duration())
 }
 
 func TestProtocol(t *testing.T) {
@@ -142,6 +151,21 @@ func TestError(t *testing.T) {
 			assert.Equal(t, tt.wantErr, report.error != nil)
 		})
 	}
+}
+
+type targetProbe struct {
+	Probe
+
+	target string
+}
+
+func (p *targetProbe) Target() string { return p.target }
+func (*targetProbe) Scheme() string   { return "chk" }
+
+func TestBuildReport_Target(t *testing.T) {
+	probe := &targetProbe{target: "example.com:443"}
+	report := BuildReport(probe, time.Now())
+	assert.Equal(t, "example.com:443", report.target)
 }
 
 func TestIsError(t *testing.T) {

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/hugoh/upd/internal/config"
 	"github.com/hugoh/upd/internal/logger"
@@ -49,16 +48,10 @@ func SetupLoop(loop *logic.Loop, configPath string) (*config.Configuration, erro
 		return nil, fmt.Errorf("invalid checks in configuration: %w", checkErr)
 	}
 
-	reports := make([]time.Duration, len(newConf.Stats.Reports))
-
-	for i, d := range newConf.Stats.Reports {
-		reports[i] = d.StdDuration()
-	}
-
 	loop.Configure(checklist,
 		newConf.GetDelays(),
 		newConf.GetDownAction(),
-		reports...)
+		newConf.GetStatServerConfig().Reports...)
 
 	return newConf, nil
 }

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/hugoh/upd/internal/config"
 	"github.com/hugoh/upd/internal/logger"
@@ -48,10 +49,16 @@ func SetupLoop(loop *logic.Loop, configPath string) (*config.Configuration, erro
 		return nil, fmt.Errorf("invalid checks in configuration: %w", checkErr)
 	}
 
+	reports := make([]time.Duration, len(newConf.Stats.Reports))
+
+	for i, d := range newConf.Stats.Reports {
+		reports[i] = d.StdDuration()
+	}
+
 	loop.Configure(checklist,
 		newConf.GetDelays(),
 		newConf.GetDownAction(),
-		newConf.Stats.Retention.StdDuration())
+		reports...)
 
 	return newConf, nil
 }

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -48,10 +48,13 @@ func SetupLoop(loop *logic.Loop, configPath string) (*config.Configuration, erro
 		return nil, fmt.Errorf("invalid checks in configuration: %w", checkErr)
 	}
 
+	statCfg := newConf.GetStatServerConfig()
+
 	loop.Configure(checklist,
 		newConf.GetDelays(),
 		newConf.GetDownAction(),
-		newConf.GetStatServerConfig().Reports...)
+		statCfg.Buckets,
+		statCfg.Reports...)
 
 	return newConf, nil
 }

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -78,6 +78,12 @@ func Run(appCtx context.Context, cmd *cli.Command) error {
 	loop := logic.NewLoop()
 
 	for {
+		if rootCtx.Err() != nil {
+			logger.App().Info("shutting down")
+
+			return nil
+		}
+
 		currentWorkerCtx, cancelCurrentWorker := context.WithCancel(rootCtx)
 
 		errCh := make(chan error, ErrChanSize)
@@ -99,26 +105,58 @@ func Run(appCtx context.Context, cmd *cli.Command) error {
 			loop.Stop(ctx)
 		}(currentWorkerCtx)
 
+		err := waitForWorker(rootCtx, sighupCh, errCh, done, cancelCurrentWorker)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// waitForWorker blocks until the current worker needs to be replaced or the
+// application should terminate. It keeps handling shutdown and reload signals
+// while the worker is running. A non-nil return value terminates the
+// application.
+func waitForWorker(
+	rootCtx context.Context,
+	sighupCh <-chan os.Signal,
+	errCh <-chan error,
+	done <-chan struct{},
+	cancelWorker context.CancelFunc,
+) error {
+	stopWorker := func() {
+		cancelWorker()
+		<-done
+	}
+
+	for {
 		select {
 		case <-rootCtx.Done():
-			logger.App().Info("shutting down")
-			cancelCurrentWorker()
-			<-done
+			stopWorker()
 
 			return nil
 		case err := <-errCh:
 			if err != nil {
-				cancelCurrentWorker()
-				<-done
+				stopWorker()
 
 				return err
 			}
-
-			<-done
+			// Configuration loaded; keep waiting for signals.
 		case <-sighupCh:
 			logger.App().Info("SIGHUP received: reloading configuration")
-			cancelCurrentWorker()
-			<-done
+			stopWorker()
+
+			return nil
+		case <-done:
+			// Worker exited on its own; surface a pending error if any.
+			select {
+			case err := <-errCh:
+				if err != nil {
+					return err
+				}
+			default:
+			}
+
+			return nil
 		}
 	}
 }

--- a/internal/cmd_test.go
+++ b/internal/cmd_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -73,6 +75,46 @@ func TestRun_WaitsForWorkerCompletion(t *testing.T) {
 	case <-done:
 	case <-timer.C:
 		t.Fatal("Run did not exit after context cancellation")
+	}
+}
+
+func TestRun_SighupReloadsConfig(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "upd.toml")
+	good, err := os.ReadFile(testConfigDir + "/upd_test_minimal.toml")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cfgPath, good, 0o600))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  ConfigConfig,
+				Value: cfgPath,
+			},
+			&cli.BoolFlag{
+				Name: ConfigDebug,
+			},
+		},
+	}
+
+	errResult := make(chan error, 1)
+
+	go func() { errResult <- Run(ctx, cmd) }()
+
+	// Let the worker start and the main loop settle into waiting.
+	time.Sleep(300 * time.Millisecond)
+
+	// Break the config; a SIGHUP-triggered reload must surface the error.
+	require.NoError(t, os.WriteFile(cfgPath, []byte("not valid toml ["), 0o600))
+	require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGHUP))
+
+	select {
+	case err := <-errResult:
+		require.Error(t, err, "reload should fail on broken config")
+	case <-time.After(2 * time.Second):
+		t.Fatal("SIGHUP did not trigger a configuration reload")
 	}
 }
 

--- a/internal/cmd_test.go
+++ b/internal/cmd_test.go
@@ -155,11 +155,11 @@ func TestSetupLoop_reload(t *testing.T) {
 
 	conf, err := SetupLoop(loop, testConfigDir+"/upd_test_reload_a.toml")
 	require.NoError(t, err)
-	assert.Equal(t, 5*time.Second, conf.GetDelays()[true])
-	assert.Equal(t, 1*time.Second, conf.GetDelays()[false])
+	assert.Equal(t, 5*time.Second, conf.GetDelays().Up)
+	assert.Equal(t, 1*time.Second, conf.GetDelays().Down)
 
 	conf, err = SetupLoop(loop, testConfigDir+"/upd_test_reload_b.toml")
 	require.NoError(t, err)
-	assert.Equal(t, 10*time.Second, conf.GetDelays()[true])
-	assert.Equal(t, 2*time.Second, conf.GetDelays()[false])
+	assert.Equal(t, 10*time.Second, conf.GetDelays().Up)
+	assert.Equal(t, 2*time.Second, conf.GetDelays().Down)
 }

--- a/internal/cmd_test.go
+++ b/internal/cmd_test.go
@@ -82,7 +82,7 @@ func TestRun_SighupReloadsConfig(t *testing.T) {
 	cfgPath := filepath.Join(t.TempDir(), "upd.toml")
 	good, err := os.ReadFile(testConfigDir + "/upd_test_minimal.toml")
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(cfgPath, good, 0o600))
+	require.NoError(t, os.WriteFile(cfgPath, good, 0o600)) // #nosec G703 -- path under t.TempDir()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,63 +170,60 @@ func expandEnvVars(content []byte) ([]byte, error) {
 	}), nil
 }
 
-// ErrNoChecks is returned when no valid checks are found in configuration.
-var ErrNoChecks = errors.New("no valid checks found in config")
+// ErrNoChecks is returned when no checks are found in configuration.
+var ErrNoChecks = errors.New("no checks found in config")
 
 // GetChecks builds a CheckList from the configuration.
+// Any invalid check fails the whole configuration.
 func (c Configuration) GetChecks() (*check.List, error) {
-	checkList := &check.List{
-		Ordered:  c.GetChecksCat(c.Checks.List.Ordered),
-		Shuffled: c.GetChecksCat(c.Checks.List.Shuffled),
+	ordered, err := c.GetChecksCat(c.Checks.List.Ordered)
+	if err != nil {
+		return nil, err
 	}
-	if len(checkList.Ordered) == 0 && len(checkList.Shuffled) == 0 {
+
+	shuffled, err := c.GetChecksCat(c.Checks.List.Shuffled)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ordered) == 0 && len(shuffled) == 0 {
 		return nil, ErrNoChecks
 	}
 
-	return checkList, nil
+	return &check.List{Ordered: ordered, Shuffled: shuffled}, nil
 }
 
 //nolint:ireturn // intentionally returns interface to abstract probe creation
-func probeFromURL(parsedURL *url.URL, checkStr string) check.Probe {
+func probeFromURL(parsedURL *url.URL) (check.Probe, error) {
 	switch parsedURL.Scheme {
 	case check.DNS:
 		probe, err := check.NewDNSProbe(parsedURL.Host, strings.TrimPrefix(parsedURL.Path, "/"))
 		if err != nil {
-			logger.Config().Error("invalid DNS check",
-				"check", checkStr, "error", err)
-
-			return nil
+			return nil, fmt.Errorf("invalid DNS check: %w", err)
 		}
 
-		return probe
+		return probe, nil
 	case check.HTTP, check.HTTPS:
-		return check.NewHTTPProbe(parsedURL.String())
+		return check.NewHTTPProbe(parsedURL.String()), nil
 	case check.TCP:
-		return check.NewTCPProbe(net.JoinHostPort(parsedURL.Hostname(), parsedURL.Port()))
+		return check.NewTCPProbe(net.JoinHostPort(parsedURL.Hostname(), parsedURL.Port())), nil
 	default:
-		logger.Config().Error("unknown protocol in config",
-			"check", checkStr,
-			"protocol", parsedURL.Scheme)
-
-		return nil
+		return nil, fmt.Errorf("%w: %q", errUnsupportedScheme, parsedURL.Scheme)
 	}
 }
 
 // GetChecksCat creates checks from a list of check URIs.
-func (c Configuration) GetChecksCat(category []string) []*check.Check {
+func (c Configuration) GetChecksCat(category []string) ([]*check.Check, error) {
 	checks := make([]*check.Check, 0, len(category))
 	for _, checkStr := range category {
 		parsedURL, err := url.Parse(checkStr)
 		if err != nil {
-			logger.Config().Error("could not parse check in config",
-				"check", checkStr, "error", err)
-
-			continue
+			return nil, fmt.Errorf("could not parse check %q: %w", checkStr, err)
 		}
 
-		probe := probeFromURL(parsedURL, checkStr)
-		if probe == nil {
-			continue
+		probe, err := probeFromURL(parsedURL)
+		if err != nil {
+			return nil, fmt.Errorf("check %q: %w", checkStr, err)
 		}
 
 		checks = append(checks, &check.Check{
@@ -235,7 +232,7 @@ func (c Configuration) GetChecksCat(category []string) []*check.Check {
 		})
 	}
 
-	return checks
+	return checks, nil
 }
 
 // GetDownAction creates a DownAction from the configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,30 +13,34 @@
 //
 // Example configuration:
 //
-//	checks:
-//	 every:
-//	   normal: 2m
-//	   down: 30s
-//	 list:
-//	   ordered:
-//	     - http://captive.apple.com/hotspot-detect.html
-//	   shuffled:
-//	     - dns://8.8.8.8/example.com
-//	 timeout: 10s
-//	downAction:
-//	 exec: "echo 'Connection down'"
-//	 every:
-//	   after: 60s
-//	   repeat: 300s
-//	stats:
-//	 port: 8080
-//	logLevel: debug
+//	logLevel = "debug"
+//
+//	[checks]
+//	timeout = "10s"
+//
+//	[checks.every]
+//	normal = "2m"
+//	down = "30s"
+//
+//	[checks.list]
+//	ordered = ["http://captive.apple.com/hotspot-detect.html"]
+//	shuffled = ["dns://8.8.8.8/example.com"]
+//
+//	[downAction]
+//	exec = "echo 'Connection down'"
+//
+//	[downAction.every]
+//	after = "60s"
+//	repeat = "300s"
+//
+//	[stats]
+//	port = 8080
 //
 // Configuration values support environment variable substitution using
 // the ${VAR} syntax in TOML string values:
 //
-//	checks:
-//	 timeout: ${UPD_TIMEOUT} // Set UPD_TIMEOUT env var to override
+//	[checks]
+//	timeout = "${UPD_TIMEOUT}" # Set UPD_TIMEOUT env var to override
 //
 // Network Security:
 //

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -268,12 +268,11 @@ func (c Configuration) GetDownAction() *logic.DownAction {
 }
 
 // GetDelays returns the check intervals for up and down states.
-func (c Configuration) GetDelays() map[bool]time.Duration {
-	delays := make(map[bool]time.Duration)
-	delays[true] = c.Checks.Every.Normal.StdDuration()
-	delays[false] = c.Checks.Every.Down.StdDuration()
-
-	return delays
+func (c Configuration) GetDelays() logic.Delays {
+	return logic.Delays{
+		Up:   c.Checks.Every.Normal.StdDuration(),
+		Down: c.Checks.Every.Down.StdDuration(),
+	}
 }
 
 // GetStatServerConfig creates a runtime stats server config from the TOML-deserialized config.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,7 +94,6 @@ type Configuration struct {
 	Stats struct {
 		Port         int        `toml:"port"`
 		Reports      []Duration `toml:"reports"`
-		Retention    Duration   `toml:"retention"`
 		ReadTimeout  Duration   `toml:"readTimeout"`
 		WriteTimeout Duration   `toml:"writeTimeout"`
 		IdleTimeout  Duration   `toml:"idleTimeout"`
@@ -273,7 +272,6 @@ func (c Configuration) GetStatServerConfig() *status.StatServerConfig {
 	return &status.StatServerConfig{
 		Port:         c.Stats.Port,
 		Reports:      reports,
-		Retention:    c.Stats.Retention.StdDuration(),
 		ReadTimeout:  c.Stats.ReadTimeout.StdDuration(),
 		WriteTimeout: c.Stats.WriteTimeout.StdDuration(),
 		IdleTimeout:  c.Stats.IdleTimeout.StdDuration(),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,13 +105,20 @@ type DownActionConfig struct {
 	StopExec string                `toml:"stopExec"`
 }
 
+// StatsBucketsConfig tunes probe-stat bucket granularity for report periods.
+type StatsBucketsConfig struct {
+	Min     int      `toml:"min"`
+	MaxSpan Duration `toml:"maxSpan"`
+}
+
 // StatsConfig holds the statistics server settings.
 type StatsConfig struct {
-	Port         int        `toml:"port"`
-	Reports      []Duration `toml:"reports"`
-	ReadTimeout  Duration   `toml:"readTimeout"`
-	WriteTimeout Duration   `toml:"writeTimeout"`
-	IdleTimeout  Duration   `toml:"idleTimeout"`
+	Port         int                `toml:"port"`
+	Reports      []Duration         `toml:"reports"`
+	Buckets      StatsBucketsConfig `toml:"buckets"`
+	ReadTimeout  Duration           `toml:"readTimeout"`
+	WriteTimeout Duration           `toml:"writeTimeout"`
+	IdleTimeout  Duration           `toml:"idleTimeout"`
 }
 
 // Configuration holds all application settings.
@@ -289,9 +296,18 @@ func (c Configuration) GetStatServerConfig() *status.StatServerConfig {
 	return &status.StatServerConfig{
 		Port:         c.Stats.Port,
 		Reports:      reports,
+		Buckets:      c.Stats.GetBucketConfig(),
 		ReadTimeout:  c.Stats.ReadTimeout.StdDuration(),
 		WriteTimeout: c.Stats.WriteTimeout.StdDuration(),
 		IdleTimeout:  c.Stats.IdleTimeout.StdDuration(),
+	}
+}
+
+// GetBucketConfig creates a runtime probe-stat bucket config.
+func (s StatsConfig) GetBucketConfig() status.BucketConfig {
+	return status.BucketConfig{
+		Min:     s.Buckets.Min,
+		MaxSpan: s.Buckets.MaxSpan.StdDuration(),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,7 +52,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -69,36 +68,54 @@ const (
 	DefaultConfig = ".upd.toml"
 )
 
+// ChecksEveryConfig holds the check intervals for up and down states.
+type ChecksEveryConfig struct {
+	Normal Duration `toml:"normal"`
+	Down   Duration `toml:"down"`
+}
+
+// ChecksListConfig holds the ordered and shuffled check URI lists.
+type ChecksListConfig struct {
+	Ordered  []string `toml:"ordered"`
+	Shuffled []string `toml:"shuffled"`
+}
+
+// ChecksConfig holds the connectivity check settings.
+type ChecksConfig struct {
+	Every   ChecksEveryConfig `toml:"every"`
+	List    ChecksListConfig  `toml:"list"`
+	TimeOut Duration          `toml:"timeout"`
+}
+
+// DownActionEveryConfig holds the down action scheduling settings.
+type DownActionEveryConfig struct {
+	After        Duration `toml:"after"`
+	Repeat       Duration `toml:"repeat"`
+	BackoffLimit Duration `toml:"expBackoffLimit"`
+}
+
+// DownActionConfig holds the down action settings.
+type DownActionConfig struct {
+	Exec     string                `toml:"exec"`
+	Every    DownActionEveryConfig `toml:"every"`
+	StopExec string                `toml:"stopExec"`
+}
+
+// StatsConfig holds the statistics server settings.
+type StatsConfig struct {
+	Port         int        `toml:"port"`
+	Reports      []Duration `toml:"reports"`
+	ReadTimeout  Duration   `toml:"readTimeout"`
+	WriteTimeout Duration   `toml:"writeTimeout"`
+	IdleTimeout  Duration   `toml:"idleTimeout"`
+}
+
 // Configuration holds all application settings.
 type Configuration struct {
-	Checks struct {
-		Every struct {
-			Normal Duration `toml:"normal"`
-			Down   Duration `toml:"down"`
-		} `toml:"every"`
-		List struct {
-			Ordered  []string `toml:"ordered"`
-			Shuffled []string `toml:"shuffled"`
-		} `toml:"list"`
-		TimeOut Duration `toml:"timeout"`
-	} `toml:"checks"`
-	DownAction struct {
-		Exec  string `toml:"exec"`
-		Every struct {
-			After        Duration `toml:"after"`
-			Repeat       Duration `toml:"repeat"`
-			BackoffLimit Duration `toml:"expBackoffLimit"`
-		} `toml:"every"`
-		StopExec string `toml:"stopExec"`
-	} `toml:"downAction"`
-	Stats struct {
-		Port         int        `toml:"port"`
-		Reports      []Duration `toml:"reports"`
-		ReadTimeout  Duration   `toml:"readTimeout"`
-		WriteTimeout Duration   `toml:"writeTimeout"`
-		IdleTimeout  Duration   `toml:"idleTimeout"`
-	} `toml:"stats"`
-	LogLevel string `toml:"logLevel"`
+	Checks     ChecksConfig     `toml:"checks"`
+	DownAction DownActionConfig `toml:"downAction"`
+	Stats      StatsConfig      `toml:"stats"`
+	LogLevel   string           `toml:"logLevel"`
 }
 
 func configError(msg string, path string, err error) (*Configuration, error) {
@@ -237,7 +254,7 @@ func (c Configuration) GetChecksCat(category []string) ([]*check.Check, error) {
 
 // GetDownAction creates a DownAction from the configuration.
 func (c Configuration) GetDownAction() *logic.DownAction {
-	if reflect.ValueOf(c.DownAction).IsZero() {
+	if c.DownAction == (DownActionConfig{}) {
 		return nil
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,11 +55,10 @@ func TestNoDownAction(t *testing.T) {
 }
 
 func (suite *TestSuite) TestGetDelaysFromConf() {
-	delays := make(map[bool]time.Duration)
-	delays[true] = 120 * time.Second
-	delays[false] = 20 * time.Second
-	conf := suite.conf.GetDelays()
-	suite.Equal(delays, conf)
+	suite.Equal(logic.Delays{
+		Up:   120 * time.Second,
+		Down: 20 * time.Second,
+	}, suite.conf.GetDelays())
 }
 
 func TestReadConf_UnsupportedSchemeFails(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,24 +25,6 @@ func readTestConfig(cfgFile string) (*Configuration, error) {
 	return ReadConf(fmt.Sprintf("%s/%s", testConfigDir, cfgFile))
 }
 
-func countProbes[T any](list *check.List) int {
-	n := 0
-
-	for _, chk := range list.Ordered {
-		if _, ok := chk.Probe.(T); ok {
-			n++
-		}
-	}
-
-	for _, chk := range list.Shuffled {
-		if _, ok := chk.Probe.(T); ok {
-			n++
-		}
-	}
-
-	return n
-}
-
 func (suite *TestSuite) SetupTest() {
 	var err error
 
@@ -80,27 +62,23 @@ func (suite *TestSuite) TestGetDelaysFromConf() {
 	suite.Equal(delays, conf)
 }
 
-func TestGetChecksIgnored(t *testing.T) {
-	conf, err := readTestConfig("upd_test_bad.toml")
-	require.NoError(t, err)
-
-	checklist, checkErr := conf.GetChecks()
-	require.NoError(t, checkErr)
-
-	totalChecks := 0
-	if checklist != nil {
-		totalChecks = len(checklist.Ordered) + len(checklist.Shuffled)
-	}
-
-	assert.Equal(t, 1, totalChecks, "2 checks should be invalid")
+func TestReadConf_UnsupportedSchemeFails(t *testing.T) {
+	_, err := readTestConfig("upd_test_bad.toml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported scheme")
 }
 
-func TestGetChecksFromConfFail(t *testing.T) {
-	conf, err := readTestConfig("upd_test_allbad.toml")
-	require.NoError(t, err)
+func TestReadConf_AllBadChecksFail(t *testing.T) {
+	_, err := readTestConfig("upd_test_allbad.toml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported scheme")
+}
 
-	_, checkErr := conf.GetChecks()
-	assert.ErrorIs(t, checkErr, ErrNoChecks, "Error expected: no valid checks")
+func TestGetChecks_NoChecks(t *testing.T) {
+	var conf Configuration
+
+	_, err := conf.GetChecks()
+	assert.ErrorIs(t, err, ErrNoChecks)
 }
 
 func (suite *TestSuite) TestGetChecks() {
@@ -128,7 +106,7 @@ func (suite *TestSuite) TestGetChecks() {
 	probe = allChecks[1].Probe
 	httpProbe, ok = probe.(*check.HTTPProbe)
 	suite.True(ok)
-	suite.Equal("http", httpProbe.Scheme())
+	suite.Equal("https", httpProbe.Scheme())
 	suite.Equal("https://example.com/", httpProbe.URL)
 
 	probe = allChecks[2].Probe
@@ -167,51 +145,22 @@ func TestReadConf_envsubst_missing(t *testing.T) {
 }
 
 func TestDNSCheckValidation_MissingDomain(t *testing.T) {
-	conf, err := readTestConfig("upd_test_bad.toml")
-	require.NoError(t, err)
+	var conf Configuration
 
-	checklist, checkErr := conf.GetChecks()
-	require.NoError(t, checkErr)
+	conf.Checks.List.Ordered = []string{"dns://8.8.4.4/"}
 
-	assert.Equal(
-		t,
-		0,
-		countProbes[*check.DNSProbe](checklist),
-		"DNS check with missing domain should be ignored",
-	)
+	_, err := conf.GetChecks()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, check.ErrDNSMissingDomain)
 }
 
 func TestDNSCheckValidation_MissingResolver(t *testing.T) {
 	conf, err := readTestConfig("upd_test_dns_missing_resolver.toml")
 	require.NoError(t, err)
 
-	checklist, checkErr := conf.GetChecks()
-	require.NoError(t, checkErr)
-
-	assert.Equal(
-		t,
-		0,
-		countProbes[*check.DNSProbe](checklist),
-		"DNS check with missing resolver host should be ignored",
-	)
-
-	httpChecks := 0
-
-	for _, chk := range checklist.Ordered {
-		_, ok := chk.Probe.(*check.HTTPProbe)
-		if ok {
-			httpChecks++
-		}
-	}
-
-	for _, chk := range checklist.Shuffled {
-		_, ok := chk.Probe.(*check.HTTPProbe)
-		if ok {
-			httpChecks++
-		}
-	}
-
-	assert.Equal(t, 1, httpChecks, "HTTP check should still be present")
+	_, checkErr := conf.GetChecks()
+	require.Error(t, checkErr)
+	assert.ErrorIs(t, checkErr, check.ErrDNSMissingResolver)
 }
 
 func TestLogSetup(t *testing.T) {

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"reflect"
 	"time"
 
 	"github.com/hugoh/upd/internal/check"
@@ -32,14 +31,8 @@ func (c Configuration) Validate() error {
 	var errs []error
 
 	errs = appendErr(errs, "checks", c.validateChecks())
-
-	if !reflect.ValueOf(c.DownAction).IsZero() {
-		errs = appendErr(errs, "downAction", c.validateDownAction())
-	}
-
-	if !reflect.ValueOf(c.Stats).IsZero() {
-		errs = appendErr(errs, "stats", c.validateStats())
-	}
+	errs = appendErr(errs, "downAction", c.validateDownAction())
+	errs = appendErr(errs, "stats", c.validateStats())
 
 	if c.LogLevel != "" {
 		errs = appendErr(errs, "logLevel", validateLogLevel(c.LogLevel))

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"reflect"
 	"time"
+
+	"github.com/hugoh/upd/internal/check"
 )
 
 var (
@@ -14,6 +16,7 @@ var (
 	errMustNotBeNegative      = errors.New("must not be negative")
 	errPortOutOfRange         = errors.New("must be between 1 and 65535")
 	errInvalidLogLevel        = errors.New("must be one of: debug, info, warn")
+	errUnsupportedScheme      = errors.New("unsupported scheme")
 )
 
 func appendErr(errs []error, key string, err error) []error {
@@ -120,15 +123,21 @@ func validateLogLevel(level string) error {
 }
 
 func validateURIs(uris []string) error {
-	if len(uris) == 0 {
-		return nil
-	}
-
 	var errs []error
 
 	for i, s := range uris {
-		if _, err := url.ParseRequestURI(s); err != nil {
+		// Same parser as GetChecksCat so validation matches what gets built.
+		parsed, err := url.Parse(s)
+		if err != nil {
 			errs = append(errs, fmt.Errorf("[%d]: %w", i, errInvalidURI))
+
+			continue
+		}
+
+		switch parsed.Scheme {
+		case check.DNS, check.HTTP, check.HTTPS, check.TCP:
+		default:
+			errs = append(errs, fmt.Errorf("[%d]: %w: %q", i, errUnsupportedScheme, parsed.Scheme))
 		}
 	}
 

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -118,11 +118,11 @@ func validateLogLevel(level string) error {
 func validateURIs(uris []string) error {
 	var errs []error
 
-	for i, s := range uris {
+	for idx, uri := range uris {
 		// Same parser as GetChecksCat so validation matches what gets built.
-		parsed, err := url.Parse(s)
+		parsed, err := url.Parse(uri)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("[%d]: %w", i, errInvalidURI))
+			errs = append(errs, fmt.Errorf("[%d]: %w", idx, errInvalidURI))
 
 			continue
 		}
@@ -130,7 +130,10 @@ func validateURIs(uris []string) error {
 		switch parsed.Scheme {
 		case check.DNS, check.HTTP, check.HTTPS, check.TCP:
 		default:
-			errs = append(errs, fmt.Errorf("[%d]: %w: %q", i, errUnsupportedScheme, parsed.Scheme))
+			errs = append(
+				errs,
+				fmt.Errorf("[%d]: %w: %q", idx, errUnsupportedScheme, parsed.Scheme),
+			)
 		}
 	}
 

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hugoh/upd/internal/check"
+	"github.com/hugoh/upd/internal/status"
 )
 
 var (
@@ -16,6 +17,7 @@ var (
 	errPortOutOfRange         = errors.New("must be between 1 and 65535")
 	errInvalidLogLevel        = errors.New("must be one of: debug, info, warn")
 	errUnsupportedScheme      = errors.New("unsupported scheme")
+	errTooManyBuckets         = errors.New("report period needs too many buckets")
 )
 
 func appendErr(errs []error, key string, err error) []error {
@@ -75,9 +77,39 @@ func (c Configuration) validateStats() error {
 	var errs []error
 
 	errs = appendErr(errs, "port", validatePort(c.Stats.Port))
+	errs = appendErr(errs, "buckets.min", checkNonNegativeInt(c.Stats.Buckets.Min))
+	errs = appendErr(
+		errs,
+		"buckets.maxSpan",
+		checkNonNegative(c.Stats.Buckets.MaxSpan.StdDuration()),
+	)
+	errs = appendErr(errs, "reports", c.Stats.validateReports())
 	errs = appendErr(errs, "readTimeout", checkNonNegative(c.Stats.ReadTimeout.StdDuration()))
 	errs = appendErr(errs, "writeTimeout", checkNonNegative(c.Stats.WriteTimeout.StdDuration()))
 	errs = appendErr(errs, "idleTimeout", checkNonNegative(c.Stats.IdleTimeout.StdDuration()))
+
+	return errors.Join(errs...)
+}
+
+func (s StatsConfig) validateReports() error {
+	bucketCfg := s.GetBucketConfig()
+
+	var errs []error
+
+	for idx, report := range s.Reports {
+		period := report.StdDuration()
+		if period <= 0 {
+			errs = append(errs, fmt.Errorf("[%d]: %w", idx, errDurationMustBePositive))
+
+			continue
+		}
+
+		if n := bucketCfg.BucketCount(period); n > status.MaxBucketsPerPeriod {
+			errs = append(errs, fmt.Errorf(
+				"[%d]: %w (%d > %d): increase buckets.maxSpan",
+				idx, errTooManyBuckets, n, status.MaxBucketsPerPeriod))
+		}
+	}
 
 	return errors.Join(errs...)
 }
@@ -92,6 +124,14 @@ func validatePositiveDuration(d Duration) error {
 
 func checkNonNegative(d time.Duration) error {
 	if d < 0 {
+		return errMustNotBeNegative
+	}
+
+	return nil
+}
+
+func checkNonNegativeInt(n int) error {
+	if n < 0 {
 		return errMustNotBeNegative
 	}
 

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -244,3 +244,74 @@ ordered = ["http://example.com/"]`)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required attributes")
 }
+
+func TestValidate_bucketsValid(t *testing.T) {
+	config := validConfigBase() + `
+
+[stats]
+reports = ["1m", "168h"]
+
+[stats.buckets]
+min = 50
+maxSpan = "30m"`
+
+	path := writeTestConfig(t, config)
+
+	_, err := ReadConf(path)
+	require.NoError(t, err)
+}
+
+func TestValidate_bucketsMinNegative(t *testing.T) {
+	config := validConfigBase() + `
+
+[stats.buckets]
+min = -1`
+
+	path := writeTestConfig(t, config)
+
+	_, err := ReadConf(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "buckets.min")
+}
+
+func TestValidate_bucketsMaxSpanNegative(t *testing.T) {
+	config := validConfigBase() + `
+
+[stats.buckets]
+maxSpan = "-5s"`
+
+	path := writeTestConfig(t, config)
+
+	_, err := ReadConf(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "buckets.maxSpan")
+}
+
+func TestValidate_reportTooManyBuckets(t *testing.T) {
+	config := validConfigBase() + `
+
+[stats]
+reports = ["168h"]
+
+[stats.buckets]
+maxSpan = "1s"`
+
+	path := writeTestConfig(t, config)
+
+	_, err := ReadConf(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many buckets")
+}
+
+func TestValidate_reportNotPositive(t *testing.T) {
+	config := validConfigBase() + `
+
+[stats]
+reports = ["1m", "0s"]`
+
+	path := writeTestConfig(t, config)
+
+	_, err := ReadConf(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reports")
+}

--- a/internal/config/duration.go
+++ b/internal/config/duration.go
@@ -22,6 +22,6 @@ func (d *Duration) UnmarshalText(text []byte) error {
 }
 
 // StdDuration returns the Duration as a standard time.Duration.
-func (d *Duration) StdDuration() time.Duration {
-	return time.Duration(*d)
+func (d Duration) StdDuration() time.Duration {
+	return time.Duration(d)
 }

--- a/internal/config/duration.go
+++ b/internal/config/duration.go
@@ -22,6 +22,6 @@ func (d *Duration) UnmarshalText(text []byte) error {
 }
 
 // StdDuration returns the Duration as a standard time.Duration.
-func (d Duration) StdDuration() time.Duration {
-	return time.Duration(d)
+func (d *Duration) StdDuration() time.Duration {
+	return time.Duration(*d)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -17,49 +17,57 @@ const (
 	logComponentApp        = "app"
 )
 
+//nolint:gochecknoglobals // application-wide logger state
+var (
+	// levelVar allows changing the log level atomically without replacing the
+	// logger, so level changes apply to all loggers already handed out.
+	levelVar = new(slog.LevelVar)
+
+	// L is the global logger instance for the application.
+	//nolint:varnamelen // Standard pattern for application-wide logger
+	L = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: levelVar,
+	}))
+
+	checkLogger      = Component(logComponentCheck)
+	downActionLogger = Component(logComponentDownAction)
+	loopLogger       = Component(logComponentLoop)
+	statsLogger      = Component(logComponentStats)
+	configLogger     = Component(logComponentConfig)
+	appLogger        = Component(logComponentApp)
+)
+
 // Component returns a logger pre-configured with the given component attribute.
 func Component(name string) *slog.Logger { return L.With(logComponent, name) }
 
 // Check returns a logger for the check component.
-func Check() *slog.Logger { return Component(logComponentCheck) }
+func Check() *slog.Logger { return checkLogger }
 
 // DownAction returns a logger for the down action component.
-func DownAction() *slog.Logger { return Component(logComponentDownAction) }
+func DownAction() *slog.Logger { return downActionLogger }
 
 // Loop returns a logger for the loop component.
-func Loop() *slog.Logger { return Component(logComponentLoop) }
+func Loop() *slog.Logger { return loopLogger }
 
 // Stats returns a logger for the stats component.
-func Stats() *slog.Logger { return Component(logComponentStats) }
+func Stats() *slog.Logger { return statsLogger }
 
 // Config returns a logger for the config component.
-func Config() *slog.Logger { return Component(logComponentConfig) }
+func Config() *slog.Logger { return configLogger }
 
 // App returns a logger for the app component.
-func App() *slog.Logger { return Component(logComponentApp) }
-
-// L is the global logger instance for the application.
-//
-//nolint:gochecknoglobals,varnamelen // Standard pattern for application-wide logger
-var L *slog.Logger
-
-func init() { //nolint:gochecknoinits // Required for global logger initialization
-	L = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
-}
+func App() *slog.Logger { return appLogger }
 
 // LogSetup configures the logger based on the debug flag.
 func LogSetup(debugFlag bool) {
 	if debugFlag {
 		SetLevel(slog.LevelDebug)
-		slog.SetDefault(L)
 	}
+
+	slog.SetDefault(L)
 }
 
 // SetLevel sets the log level of the global logger.
 func SetLevel(level slog.Level) {
-	L = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: level,
-	}))
+	levelVar.Set(level)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -8,23 +8,28 @@ import (
 )
 
 func TestLogSetup_DebugFlagTrue(t *testing.T) {
-	originalLogger := L
-
-	defer func() { L = originalLogger }()
+	defer SetLevel(slog.LevelInfo)
 
 	LogSetup(true)
-	assert.NotNil(t, L)
+	assert.True(t, L.Enabled(t.Context(), slog.LevelDebug))
 }
 
 func TestLogSetup_DebugFlagFalse(t *testing.T) {
-	originalLogger := L
+	defer SetLevel(slog.LevelInfo)
 
-	defer func() { L = originalLogger }()
-
-	L = slog.New(slog.NewTextHandler(nil, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	}))
-
+	SetLevel(slog.LevelInfo)
 	LogSetup(false)
-	assert.NotNil(t, L)
+	assert.False(t, L.Enabled(t.Context(), slog.LevelDebug))
+	assert.True(t, L.Enabled(t.Context(), slog.LevelInfo))
+}
+
+func TestSetLevel_AppliesToExistingLoggers(t *testing.T) {
+	defer SetLevel(slog.LevelInfo)
+
+	chk := Check()
+	assert.False(t, chk.Enabled(t.Context(), slog.LevelDebug))
+
+	SetLevel(slog.LevelDebug)
+	assert.True(t, chk.Enabled(t.Context(), slog.LevelDebug),
+		"level change should apply to loggers handed out earlier")
 }

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -254,15 +254,13 @@ func (dal *DownActionLoop) run(ctx context.Context) {
 
 	for {
 		logger.DownAction().Debug("sleeping", "duration", time.Duration(dal.sleepTime.Load()))
-		timer := time.NewTimer(time.Duration(dal.sleepTime.Load()))
 
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			logger.DownAction().Debug("canceled")
 
 			return
-		case <-timer.C:
+		case <-time.After(time.Duration(dal.sleepTime.Load())):
 		}
 
 		dal.killCurrentCmd()

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -28,16 +28,17 @@ type DownAction struct {
 
 // DownActionLoop manages execution of down action commands.
 type DownActionLoop struct {
-	da         *DownAction
-	cancelFunc context.CancelFunc
-	//nolint:containedctx // loopCtx stored to bind StopExec commands on loop exit
-	loopCtx      context.Context
+	da           *DownAction
+	cancelFunc   context.CancelFunc
 	iteration    atomic.Uint32
 	sleepTime    atomic.Int64
 	limitReached atomic.Bool
 	currentCmd   *exec.Cmd
 	cmdMu        sync.Mutex
 }
+
+// StopExecTimeout bounds how long the stop command may run.
+const StopExecTimeout = 30 * time.Second
 
 // BackoffFactor is the multiplier for exponential backoff.
 // Each iteration beyond the second will increase the delay by this factor.
@@ -63,20 +64,23 @@ func validateCommand(command []string) error {
 	return nil
 }
 
-// Execute runs the specified command string with the iteration context.
-func (dal *DownActionLoop) Execute(ctx context.Context, execString string) error {
+// startCommand parses, validates, and starts the given command string.
+func (dal *DownActionLoop) startCommand(
+	ctx context.Context,
+	execString string,
+) (*exec.Cmd, *bytes.Buffer, error) {
 	if execString == "" {
-		return ErrNoCommand
+		return nil, nil, ErrNoCommand
 	}
 
 	command, errSh := shlex.Split(execString)
 	if errSh != nil {
-		return fmt.Errorf("failed to parse DownAction definition: %w", errSh)
+		return nil, nil, fmt.Errorf("failed to parse DownAction definition: %w", errSh)
 	}
 
 	err := validateCommand(command)
 	if err != nil {
-		return fmt.Errorf("invalid command: %w", err)
+		return nil, nil, fmt.Errorf("invalid command: %w", err)
 	}
 
 	iteration := dal.iteration.Load()
@@ -88,9 +92,7 @@ func (dal *DownActionLoop) Execute(ctx context.Context, execString string) error
 
 	cmd.Stderr = &stderrBuf
 
-	cmdEnv := os.Environ()
-	cmdEnv = append(cmdEnv, fmt.Sprintf("UPD_ITERATION=%d", iteration))
-	cmd.Env = cmdEnv
+	cmd.Env = append(os.Environ(), fmt.Sprintf("UPD_ITERATION=%d", iteration))
 	logger.DownAction().Info("executing command",
 		"exec", cmd.String(),
 		"iteration", iteration,
@@ -100,14 +102,24 @@ func (dal *DownActionLoop) Execute(ctx context.Context, execString string) error
 		logger.DownAction().Error("failed to run",
 			"exec", cmd.String(), "error", err)
 
-		return fmt.Errorf("failed to execute DownAction: %w", err)
+		return nil, nil, fmt.Errorf("failed to execute DownAction: %w", err)
+	}
+
+	return cmd, &stderrBuf, nil
+}
+
+// Execute runs the specified command string with the iteration context.
+func (dal *DownActionLoop) Execute(ctx context.Context, execString string) error {
+	cmd, stderrBuf, err := dal.startCommand(ctx, execString)
+	if err != nil {
+		return err
 	}
 
 	dal.cmdMu.Lock()
 	dal.currentCmd = cmd
 	dal.cmdMu.Unlock()
 
-	go dal.waitForCmd(cmd, &stderrBuf)
+	go dal.waitForCmd(cmd, stderrBuf)
 
 	return nil
 }
@@ -118,7 +130,6 @@ func (da *DownAction) NewDownActionLoop(ctx context.Context) (*DownActionLoop, c
 	dal := &DownActionLoop{
 		da:         da,
 		cancelFunc: cancelFunc,
-		loopCtx:    ctx,
 	}
 	dal.sleepTime.Store(int64(da.After))
 
@@ -136,21 +147,32 @@ func (da *DownAction) Start(ctx context.Context) *DownActionLoop {
 	return dal
 }
 
-// Stop cancels the down action loop and executes the stop command.
-// The stop command is bound to loopCtx so cancelFunc kills it on loop exit.
+// Stop cancels the down action loop, kills any running command, and runs the
+// stop command to completion. The stop command gets its own timeout-bounded
+// context so loop cancellation cannot kill it.
 func (dal *DownActionLoop) Stop(_ context.Context) {
+	logger.DownAction().Debug("sending shutdown signal")
+	dal.cancelFunc()
 	dal.killCurrentCmd()
 
 	if dal.da.StopExec != "" {
-		//nolint:contextcheck // loopCtx derived from the same hierarchy as ctx
-		err := dal.Execute(dal.loopCtx, dal.da.StopExec)
-		if err != nil && !errors.Is(err, ErrNoCommand) {
-			logger.DownAction().Warn("failed to execute stop command", "error", err)
-		}
+		dal.runStopExec()
+	}
+}
+
+func (dal *DownActionLoop) runStopExec() {
+	//nolint:contextcheck // intentionally detached: must survive loop cancellation
+	ctx, cancel := context.WithTimeout(context.Background(), StopExecTimeout)
+	defer cancel()
+
+	cmd, stderrBuf, err := dal.startCommand(ctx, dal.da.StopExec)
+	if err != nil {
+		logger.DownAction().Warn("failed to execute stop command", "error", err)
+
+		return
 	}
 
-	logger.DownAction().Debug("sending shutdown signal")
-	dal.cancelFunc()
+	dal.waitForCmd(cmd, stderrBuf)
 }
 
 // Status returns a snapshot of the current down action loop state.

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -64,50 +64,6 @@ func validateCommand(command []string) error {
 	return nil
 }
 
-// startCommand parses, validates, and starts the given command string.
-func (dal *DownActionLoop) startCommand(
-	ctx context.Context,
-	execString string,
-) (*exec.Cmd, *bytes.Buffer, error) {
-	if execString == "" {
-		return nil, nil, ErrNoCommand
-	}
-
-	command, errSh := shlex.Split(execString)
-	if errSh != nil {
-		return nil, nil, fmt.Errorf("failed to parse DownAction definition: %w", errSh)
-	}
-
-	err := validateCommand(command)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid command: %w", err)
-	}
-
-	iteration := dal.iteration.Load()
-
-	// #nosec G204 // Command is validated by shlex.Split() and validateCommand() before execution
-	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
-
-	var stderrBuf bytes.Buffer
-
-	cmd.Stderr = &stderrBuf
-
-	cmd.Env = append(os.Environ(), fmt.Sprintf("UPD_ITERATION=%d", iteration))
-	logger.DownAction().Info("executing command",
-		"exec", cmd.String(),
-		"iteration", iteration,
-	)
-
-	if err = cmd.Start(); err != nil {
-		logger.DownAction().Error("failed to run",
-			"exec", cmd.String(), "error", err)
-
-		return nil, nil, fmt.Errorf("failed to execute DownAction: %w", err)
-	}
-
-	return cmd, &stderrBuf, nil
-}
-
 // Execute runs the specified command string with the iteration context.
 func (dal *DownActionLoop) Execute(ctx context.Context, execString string) error {
 	cmd, stderrBuf, err := dal.startCommand(ctx, execString)
@@ -156,12 +112,67 @@ func (dal *DownActionLoop) Stop(_ context.Context) {
 	dal.killCurrentCmd()
 
 	if dal.da.StopExec != "" {
+		//nolint:contextcheck // intentionally detached: must survive loop cancellation
 		dal.runStopExec()
 	}
 }
 
+// Status returns a snapshot of the current down action loop state.
+func (dal *DownActionLoop) Status() status.DownActionStatus {
+	return status.DownActionStatus{
+		Iteration:     dal.iteration.Load(),
+		SleepTime:     status.ReadableDuration(time.Duration(dal.sleepTime.Load())),
+		BackoffCapped: dal.limitReached.Load(),
+	}
+}
+
+// startCommand parses, validates, and starts the given command string.
+func (dal *DownActionLoop) startCommand(
+	ctx context.Context,
+	execString string,
+) (*exec.Cmd, *bytes.Buffer, error) {
+	if execString == "" {
+		return nil, nil, ErrNoCommand
+	}
+
+	command, errSh := shlex.Split(execString)
+	if errSh != nil {
+		return nil, nil, fmt.Errorf("failed to parse DownAction definition: %w", errSh)
+	}
+
+	err := validateCommand(command)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid command: %w", err)
+	}
+
+	iteration := dal.iteration.Load()
+
+	// #nosec G204 // Command is validated by shlex.Split() and validateCommand() before execution
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+
+	var stderrBuf bytes.Buffer
+
+	cmd.Stderr = &stderrBuf
+
+	cmd.Env = append(os.Environ(), fmt.Sprintf("UPD_ITERATION=%d", iteration))
+	logger.DownAction().Info("executing command",
+		"exec", cmd.String(),
+		"iteration", iteration,
+	)
+
+	if err = cmd.Start(); err != nil {
+		logger.DownAction().Error("failed to run",
+			"exec", cmd.String(), "error", err)
+
+		return nil, nil, fmt.Errorf("failed to execute DownAction: %w", err)
+	}
+
+	return cmd, &stderrBuf, nil
+}
+
+// runStopExec runs the stop command to completion on a context detached from
+// the loop so cancellation cannot kill it, bounded by StopExecTimeout.
 func (dal *DownActionLoop) runStopExec() {
-	//nolint:contextcheck // intentionally detached: must survive loop cancellation
 	ctx, cancel := context.WithTimeout(context.Background(), StopExecTimeout)
 	defer cancel()
 
@@ -173,15 +184,6 @@ func (dal *DownActionLoop) runStopExec() {
 	}
 
 	dal.waitForCmd(cmd, stderrBuf)
-}
-
-// Status returns a snapshot of the current down action loop state.
-func (dal *DownActionLoop) Status() status.DownActionStatus {
-	return status.DownActionStatus{
-		Iteration:     dal.iteration.Load(),
-		SleepTime:     status.ReadableDuration(time.Duration(dal.sleepTime.Load())),
-		BackoffCapped: dal.limitReached.Load(),
-	}
 }
 
 func (dal *DownActionLoop) waitForCmd(cmd *exec.Cmd, stderrBuf *bytes.Buffer) {

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -211,13 +211,12 @@ func (dal *DownActionLoop) killCurrentCmd() {
 		return
 	}
 
+	// currentCmd is only set after a successful Start, so Process is non-nil.
 	logger.DownAction().Warn("killing current command",
 		"pid", dal.currentCmd.Process.Pid)
 
-	if dal.currentCmd.Process != nil {
-		if err := dal.currentCmd.Process.Kill(); err != nil {
-			logger.DownAction().Warn("failed to kill current command", "error", err)
-		}
+	if err := dal.currentCmd.Process.Kill(); err != nil {
+		logger.DownAction().Warn("failed to kill current command", "error", err)
 	}
 
 	dal.currentCmd = nil

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -32,7 +32,7 @@ type DownActionLoop struct {
 	cancelFunc context.CancelFunc
 	//nolint:containedctx // loopCtx stored to bind StopExec commands on loop exit
 	loopCtx      context.Context
-	iteration    atomic.Uint64
+	iteration    atomic.Uint32
 	sleepTime    time.Duration
 	limitReached bool
 	currentCmd   *exec.Cmd

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -33,8 +33,8 @@ type DownActionLoop struct {
 	//nolint:containedctx // loopCtx stored to bind StopExec commands on loop exit
 	loopCtx      context.Context
 	iteration    atomic.Uint32
-	sleepTime    time.Duration
-	limitReached bool
+	sleepTime    atomic.Int64
+	limitReached atomic.Bool
 	currentCmd   *exec.Cmd
 	cmdMu        sync.Mutex
 }
@@ -119,8 +119,8 @@ func (da *DownAction) NewDownActionLoop(ctx context.Context) (*DownActionLoop, c
 		da:         da,
 		cancelFunc: cancelFunc,
 		loopCtx:    ctx,
-		sleepTime:  da.After,
 	}
+	dal.sleepTime.Store(int64(da.After))
 
 	return dal, ctx
 }
@@ -157,8 +157,8 @@ func (dal *DownActionLoop) Stop(_ context.Context) {
 func (dal *DownActionLoop) Status() status.DownActionStatus {
 	return status.DownActionStatus{
 		Iteration:     dal.iteration.Load(),
-		SleepTime:     status.ReadableDuration(dal.sleepTime),
-		BackoffCapped: dal.limitReached,
+		SleepTime:     status.ReadableDuration(time.Duration(dal.sleepTime.Load())),
+		BackoffCapped: dal.limitReached.Load(),
 	}
 }
 
@@ -206,33 +206,34 @@ func (dal *DownActionLoop) nextSleep() time.Duration {
 
 	switch dal.iteration.Load() {
 	case 1:
-		dal.sleepTime = dal.da.Every
+		dal.sleepTime.Store(int64(dal.da.Every))
 	default:
-		if !dal.limitReached {
-			next := time.Duration(BackoffFactor * float64(dal.sleepTime))
+		if !dal.limitReached.Load() {
+			next := time.Duration(BackoffFactor * float64(dal.sleepTime.Load()))
 			if dal.da.BackoffLimit != 0 && next >= dal.da.BackoffLimit {
 				next = dal.da.BackoffLimit
-				dal.limitReached = true
+				dal.limitReached.Store(true)
 			}
 
-			dal.sleepTime = next
+			dal.sleepTime.Store(int64(next))
 		}
 	}
 
+	sleepTime := time.Duration(dal.sleepTime.Load())
 	logger.DownAction().Debug("iteration details",
 		"iteration", dal.iteration.Load(),
-		"sleepTime", dal.sleepTime,
-		"limitReached", dal.limitReached)
+		"sleepTime", sleepTime,
+		"limitReached", dal.limitReached.Load())
 
-	return dal.sleepTime
+	return sleepTime
 }
 
 func (dal *DownActionLoop) run(ctx context.Context) {
 	logger.DownAction().Debug("down action loop started")
 
 	for {
-		logger.DownAction().Debug("sleeping", "duration", dal.sleepTime)
-		timer := time.NewTimer(dal.sleepTime)
+		logger.DownAction().Debug("sleeping", "duration", time.Duration(dal.sleepTime.Load()))
+		timer := time.NewTimer(time.Duration(dal.sleepTime.Load()))
 
 		select {
 		case <-ctx.Done():
@@ -258,7 +259,7 @@ func (dal *DownActionLoop) run(ctx context.Context) {
 		}
 
 		if dal.da.Every > 0 {
-			dal.sleepTime = dal.nextSleep()
+			dal.nextSleep()
 		} else {
 			logger.DownAction().Debug("down action loop complete")
 

--- a/internal/logic/downaction_test.go
+++ b/internal/logic/downaction_test.go
@@ -1,6 +1,8 @@
 package logic
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -73,6 +75,23 @@ func Test_ExecuteStderrCapture_Trimmed(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 }
 
+func Test_Stop_RunsStopExecToCompletion(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "stopped")
+	da := &DownAction{
+		Exec:     "sleep 10",
+		StopExec: "sh -c 'sleep 0.1 && touch " + marker + "'",
+	}
+
+	dal := da.Start(t.Context())
+
+	time.Sleep(100 * time.Millisecond)
+
+	dal.Stop(t.Context())
+
+	_, err := os.Stat(marker)
+	require.NoError(t, err, "stop command should run to completion")
+}
+
 func Test_killCurrentCmd_nilCmd(t *testing.T) {
 	da := &DownAction{}
 	dal, _ := da.NewDownActionLoop(t.Context())
@@ -122,12 +141,9 @@ func Test_ExecuteReplacesStaleCmd(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 }
 
-func Test_StopUsesLoopCtx(t *testing.T) {
+func Test_StopCancelsLoopCtx(t *testing.T) {
 	da := &DownAction{}
 	dal, ctx := da.NewDownActionLoop(t.Context())
-
-	assert.NotNil(t, dal.loopCtx, "loopCtx should be stored")
-	assert.Equal(t, ctx, dal.loopCtx, "loopCtx matches returned child context")
 
 	dal.Stop(t.Context())
 
@@ -135,9 +151,9 @@ func Test_StopUsesLoopCtx(t *testing.T) {
 	defer timer.Stop()
 
 	select {
-	case <-dal.loopCtx.Done():
+	case <-ctx.Done():
 	case <-timer.C:
-		t.Fatal("loopCtx should be cancelled after Stop")
+		t.Fatal("loop context should be cancelled after Stop")
 	}
 }
 

--- a/internal/logic/downaction_test.go
+++ b/internal/logic/downaction_test.go
@@ -190,8 +190,8 @@ func testBackoff(t *testing.T, hasLimit bool) {
 
 	dal, _ := da.NewDownActionLoop(t.Context())
 	assert.Equal(t, uint32(0), dal.iteration.Load())
-	assert.Equal(t, da.After, dal.sleepTime)
-	assert.False(t, dal.limitReached)
+	assert.Equal(t, da.After, time.Duration(dal.sleepTime.Load()))
+	assert.False(t, dal.limitReached.Load())
 
 	sleepTime := dal.nextSleep()
 	assert.Equal(t, uint32(1), dal.iteration.Load())
@@ -206,10 +206,10 @@ func testBackoff(t *testing.T, hasLimit bool) {
 
 	if hasLimit {
 		assert.Equal(t, da.BackoffLimit, sleepTime)
-		assert.True(t, dal.limitReached)
+		assert.True(t, dal.limitReached.Load())
 	} else {
 		assert.Equal(t, time.Duration(2.25*float64(time.Second)), sleepTime)
-		assert.False(t, dal.limitReached)
+		assert.False(t, dal.limitReached.Load())
 	}
 }
 

--- a/internal/logic/downaction_test.go
+++ b/internal/logic/downaction_test.go
@@ -189,20 +189,20 @@ func testBackoff(t *testing.T, hasLimit bool) {
 	assert.InEpsilon(t, 1.5, BackoffFactor, 0.01, "Ensuring we have the right values")
 
 	dal, _ := da.NewDownActionLoop(t.Context())
-	assert.Equal(t, uint64(0), dal.iteration.Load())
+	assert.Equal(t, uint32(0), dal.iteration.Load())
 	assert.Equal(t, da.After, dal.sleepTime)
 	assert.False(t, dal.limitReached)
 
 	sleepTime := dal.nextSleep()
-	assert.Equal(t, uint64(1), dal.iteration.Load())
+	assert.Equal(t, uint32(1), dal.iteration.Load())
 	assert.Equal(t, da.Every, sleepTime)
 
 	sleepTime = dal.nextSleep()
-	assert.Equal(t, uint64(2), dal.iteration.Load())
+	assert.Equal(t, uint32(2), dal.iteration.Load())
 	assert.Equal(t, time.Duration(1.5*float64(time.Second)), sleepTime)
 
 	sleepTime = dal.nextSleep()
-	assert.Equal(t, uint64(3), dal.iteration.Load())
+	assert.Equal(t, uint32(3), dal.iteration.Load())
 
 	if hasLimit {
 		assert.Equal(t, da.BackoffLimit, sleepTime)
@@ -226,7 +226,7 @@ func Test_Status_Initial(t *testing.T) {
 	dal, _ := da.NewDownActionLoop(t.Context())
 
 	st := dal.Status()
-	assert.Equal(t, uint64(0), st.Iteration)
+	assert.Equal(t, uint32(0), st.Iteration)
 	assert.Zero(t, st.SleepTime)
 	assert.False(t, st.BackoffCapped)
 }
@@ -237,13 +237,13 @@ func Test_Status_AfterIteration(t *testing.T) {
 
 	dal.nextSleep()
 	st := dal.Status()
-	assert.Equal(t, uint64(1), st.Iteration)
+	assert.Equal(t, uint32(1), st.Iteration)
 	assert.Equal(t, da.Every, time.Duration(st.SleepTime))
 	assert.False(t, st.BackoffCapped)
 
 	dal.nextSleep()
 	st = dal.Status()
-	assert.Equal(t, uint64(2), st.Iteration)
+	assert.Equal(t, uint32(2), st.Iteration)
 	assert.InEpsilon(t, 1.5*float64(time.Second), float64(time.Duration(st.SleepTime)), 0.01)
 	assert.False(t, st.BackoffCapped)
 }

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -27,7 +27,7 @@
 //		true:  2 * time.Minute,  // Check every 2 minutes when up
 //		false: 30 * time.Second,  // Check every 30 seconds when down
 //	}
-//	loop.Configure(checks, delays, nil, 24*time.Hour)
+//	loop.Configure(checks, delays, nil, time.Minute, 5*time.Minute)
 //	go loop.Run(ctx, nil)
 //
 // Down Actions:
@@ -48,7 +48,7 @@
 //		Exec:         "/usr/local/bin/notify-down",
 //		StopExec:     "/usr/local/bin/notify-up",
 //	}
-//	loop.Configure(checks, delays, downAction, 24*time.Hour)
+//	loop.Configure(checks, delays, downAction, time.Minute, 5*time.Minute)
 //
 // Configuration:
 //
@@ -56,7 +56,7 @@
 //   - checkList: List of probes to execute
 //   - delays: Check intervals for up/down states
 //   - downAction: Optional down action configuration
-//   - retention: How long to keep status history (for statistics)
+//   - periods: Report periods for statistics (retention is derived from the max period)
 //
 // Context and Cancellation:
 //
@@ -115,16 +115,27 @@ func (l *Loop) Configure(
 	checkList *check.List,
 	delays Delays,
 	downAction *DownAction,
-	retention time.Duration,
+	periods ...time.Duration,
 ) {
 	l.checkList = checkList
 	l.delays = delays
 	l.downAction = downAction
+
+	var retention time.Duration
+	for _, p := range periods {
+		if p > retention {
+			retention = p
+		}
+	}
+
 	l.status.SetRetention(retention)
 
 	if retention > 0 {
-		l.rollingTracker = status.NewRollingProbeTracker(retention)
+		l.rollingTracker = status.NewRollingProbeTracker(retention, status.BucketInterval(periods))
 		l.status.SetRollingTracker(l.rollingTracker)
+	} else {
+		l.rollingTracker = nil
+		l.status.SetRollingTracker(nil)
 	}
 }
 

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -98,6 +98,7 @@ type Loop struct {
 	downActionLoop *DownActionLoop
 	statServer     *status.StatServer
 	status         *status.Status
+	rollingTracker *status.RollingProbeTracker
 	lastSuccess    time.Time
 	nextCheckAt    time.Time
 }
@@ -120,6 +121,11 @@ func (l *Loop) Configure(
 	l.delays = delays
 	l.downAction = downAction
 	l.status.SetRetention(retention)
+
+	if retention > 0 {
+		l.rollingTracker = status.NewRollingProbeTracker(retention)
+		l.status.SetRollingTracker(l.rollingTracker)
+	}
 }
 
 // ErrDownActionRunning is returned when trying to start a down action while one is active.
@@ -162,7 +168,7 @@ func (l *Loop) ProcessCheck(ctx context.Context, upStatus bool) {
 
 // Run starts the monitoring loop with optional statistics server config.
 func (l *Loop) Run(ctx context.Context, statServerConfig *status.StatServerConfig) {
-	var checker LoopChecker
+	checker := LoopChecker{tracker: l.rollingTracker}
 
 	if l.statServer == nil {
 		l.statServer = status.StartStatServer(l.status, statServerConfig)
@@ -244,8 +250,11 @@ func (l *Loop) pushStatus() {
 	}
 }
 
-// LoopChecker implements check.Checker for logging check lifecycle events.
-type LoopChecker struct{}
+// LoopChecker implements check.Checker for logging check lifecycle events and
+// probe-level stats collection.
+type LoopChecker struct {
+	tracker *status.RollingProbeTracker
+}
 
 // CheckRun logs the start of a check.
 func (LoopChecker) CheckRun(chk check.Check) {
@@ -260,11 +269,19 @@ func (LoopChecker) CheckRun(chk check.Check) {
 }
 
 // ProbeSuccess logs successful probe results.
-func (LoopChecker) ProbeSuccess(report *check.Report) {
+func (c LoopChecker) ProbeSuccess(report *check.Report) {
 	logger.Check().Debug("success", report.LogAttrs())
+
+	if c.tracker != nil {
+		c.tracker.Record(false)
+	}
 }
 
 // ProbeFailure logs failed probe results.
-func (LoopChecker) ProbeFailure(report *check.Report) {
+func (c LoopChecker) ProbeFailure(report *check.Report) {
 	logger.Check().Warn("failed", report.LogAttrs())
+
+	if c.tracker != nil {
+		c.tracker.Record(true)
+	}
 }

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -198,21 +198,9 @@ func (l *Loop) Run(ctx context.Context, statServerConfig *status.StatServerConfi
 	}
 
 	for {
-		checkStatus, err := check.CheckerRun(ctx, checker, l.checkList.GetIterator())
-		if err == nil {
-			l.lastSuccess = time.Now()
-			l.ProcessCheck(ctx, checkStatus)
-		} else {
-			attrs := []any{"error", err}
-			if !l.lastSuccess.IsZero() {
-				attrs = append(attrs, "sinceLastSuccess", time.Since(l.lastSuccess))
-			}
-
-			logger.Loop().Error("loop error", attrs...)
-
-			l.nextCheckAt = time.Now().Add(l.delays.ForStatus(l.status.Up))
-			l.pushStatus()
-		}
+		checkStatus := check.CheckerRun(ctx, checker, l.checkList.All())
+		l.lastSuccess = time.Now()
+		l.ProcessCheck(ctx, checkStatus)
 
 		sleepTime := l.delays.ForStatus(l.status.Up)
 		logger.Loop().Debug("waiting for next loop iteration", "wait", sleepTime)

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -8,9 +8,9 @@
 //   - Normal interval: Used when connection is up
 //   - Down interval: Used when connection is down (typically more frequent)
 //
-// The loop uses a Delays map with boolean keys:
-//   - true: Normal interval (connection up)
-//   - false: Down interval (connection down)
+// The loop uses a Delays struct:
+//   - Up: Normal interval (connection up)
+//   - Down: Down interval (connection down)
 //
 // Example - Creating and running a loop:
 //
@@ -24,8 +24,8 @@
 //		},
 //	}
 //	delays := logic.Delays{
-//		true:  2 * time.Minute,  // Check every 2 minutes when up
-//		false: 30 * time.Second,  // Check every 30 seconds when down
+//		Up:   2 * time.Minute,  // Check every 2 minutes when up
+//		Down: 30 * time.Second, // Check every 30 seconds when down
 //	}
 //	loop.Configure(checks, delays, nil, time.Minute, 5*time.Minute)
 //	go loop.Run(ctx, nil)
@@ -87,8 +87,20 @@ import (
 	"github.com/hugoh/upd/internal/status"
 )
 
-// Delays maps connection state to check interval durations.
-type Delays map[bool]time.Duration
+// Delays holds the check interval durations for up and down states.
+type Delays struct {
+	Up   time.Duration
+	Down time.Duration
+}
+
+// ForStatus returns the check interval for the given connection state.
+func (d Delays) ForStatus(up bool) time.Duration {
+	if up {
+		return d.Up
+	}
+
+	return d.Down
+}
 
 // Loop manages periodic network connectivity checks.
 type Loop struct {
@@ -173,7 +185,7 @@ func (l *Loop) ProcessCheck(ctx context.Context, upStatus bool) {
 		l.handleStateChange(ctx, upStatus)
 	}
 
-	l.nextCheckAt = time.Now().Add(l.delays[l.status.Up])
+	l.nextCheckAt = time.Now().Add(l.delays.ForStatus(l.status.Up))
 	l.pushStatus()
 }
 
@@ -198,11 +210,11 @@ func (l *Loop) Run(ctx context.Context, statServerConfig *status.StatServerConfi
 
 			logger.Loop().Error("loop error", attrs...)
 
-			l.nextCheckAt = time.Now().Add(l.delays[l.status.Up])
+			l.nextCheckAt = time.Now().Add(l.delays.ForStatus(l.status.Up))
 			l.pushStatus()
 		}
 
-		sleepTime := l.delays[l.status.Up]
+		sleepTime := l.delays.ForStatus(l.status.Up)
 		logger.Loop().Debug("waiting for next loop iteration", "wait", sleepTime)
 
 		timer := time.NewTimer(sleepTime)
@@ -244,7 +256,7 @@ func (l *Loop) handleStateChange(ctx context.Context, upStatus bool) {
 
 func (l *Loop) pushStatus() {
 	loopSt := status.LoopStatus{
-		Interval: status.ReadableDuration(l.delays[l.status.Up]),
+		Interval: status.ReadableDuration(l.delays.ForStatus(l.status.Up)),
 	}
 
 	l.status.SetLoopStatus(loopSt)

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -27,7 +27,7 @@
 //		Up:   2 * time.Minute,  // Check every 2 minutes when up
 //		Down: 30 * time.Second, // Check every 30 seconds when down
 //	}
-//	loop.Configure(checks, delays, nil, time.Minute, 5*time.Minute)
+//	loop.Configure(checks, delays, nil, status.BucketConfig{}, time.Minute, 5*time.Minute)
 //	go loop.Run(ctx, nil)
 //
 // Down Actions:
@@ -48,7 +48,7 @@
 //		Exec:         "/usr/local/bin/notify-down",
 //		StopExec:     "/usr/local/bin/notify-up",
 //	}
-//	loop.Configure(checks, delays, downAction, time.Minute, 5*time.Minute)
+//	loop.Configure(checks, delays, downAction, status.BucketConfig{}, time.Minute, 5*time.Minute)
 //
 // Configuration:
 //
@@ -56,6 +56,7 @@
 //   - checkList: List of probes to execute
 //   - delays: Check intervals for up/down states
 //   - downAction: Optional down action configuration
+//   - buckets: Probe-stat bucket granularity tuning (zero value for defaults)
 //   - periods: Report periods for statistics (retention is derived from the max period)
 //
 // Context and Cancellation:
@@ -127,6 +128,7 @@ func (l *Loop) Configure(
 	checkList *check.List,
 	delays Delays,
 	downAction *DownAction,
+	buckets status.BucketConfig,
 	periods ...time.Duration,
 ) {
 	l.checkList = checkList
@@ -143,7 +145,7 @@ func (l *Loop) Configure(
 	l.status.SetRetention(retention)
 
 	if retention > 0 {
-		l.rollingTracker = status.NewRollingProbeTracker(retention, status.BucketInterval(periods))
+		l.rollingTracker = status.NewRollingProbeTracker(periods, buckets)
 		l.status.SetRollingTracker(l.rollingTracker)
 	} else {
 		l.rollingTracker = nil

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -205,14 +205,12 @@ func (l *Loop) Run(ctx context.Context, statServerConfig *status.StatServerConfi
 		sleepTime := l.delays.ForStatus(l.status.Up)
 		logger.Loop().Debug("waiting for next loop iteration", "wait", sleepTime)
 
-		timer := time.NewTimer(sleepTime)
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			logger.Loop().Debug("context canceled during sleep, exiting Run()")
 
 			return
-		case <-timer.C:
+		case <-time.After(sleepTime):
 		}
 	}
 }

--- a/internal/logic/loop_run_test.go
+++ b/internal/logic/loop_run_test.go
@@ -17,7 +17,6 @@ func TestRun_StopsOnContextCancel(t *testing.T) {
 		emptyCheckList,
 		Delays{true: 1 * time.Second, false: 1 * time.Second},
 		nil,
-		0,
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -47,7 +46,6 @@ func TestRun_ProcessesChecks(t *testing.T) {
 		checkList,
 		Delays{true: 10 * time.Millisecond, false: 10 * time.Millisecond},
 		nil,
-		0,
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -67,7 +65,6 @@ func TestStop_StopsStatServer(t *testing.T) {
 		emptyCheckList,
 		Delays{true: 1 * time.Second, false: 1 * time.Second},
 		nil,
-		0,
 	)
 
 	ctx := t.Context()

--- a/internal/logic/loop_run_test.go
+++ b/internal/logic/loop_run_test.go
@@ -15,7 +15,7 @@ func TestRun_StopsOnContextCancel(t *testing.T) {
 	emptyCheckList := &check.List{}
 	loop.Configure(
 		emptyCheckList,
-		Delays{true: 1 * time.Second, false: 1 * time.Second},
+		Delays{Up: 1 * time.Second, Down: 1 * time.Second},
 		nil,
 	)
 
@@ -44,7 +44,7 @@ func TestRun_ProcessesChecks(t *testing.T) {
 
 	loop.Configure(
 		checkList,
-		Delays{true: 10 * time.Millisecond, false: 10 * time.Millisecond},
+		Delays{Up: 10 * time.Millisecond, Down: 10 * time.Millisecond},
 		nil,
 	)
 
@@ -63,7 +63,7 @@ func TestStop_StopsStatServer(t *testing.T) {
 	emptyCheckList := &check.List{}
 	loop.Configure(
 		emptyCheckList,
-		Delays{true: 1 * time.Second, false: 1 * time.Second},
+		Delays{Up: 1 * time.Second, Down: 1 * time.Second},
 		nil,
 	)
 
@@ -82,7 +82,7 @@ func TestRun_StopsTimerOnContextCancel(t *testing.T) {
 	longDelay := 10 * time.Second
 	loop.Configure(
 		emptyCheckList,
-		Delays{true: longDelay, false: longDelay},
+		Delays{Up: longDelay, Down: longDelay},
 		nil,
 		0,
 	)

--- a/internal/logic/loop_run_test.go
+++ b/internal/logic/loop_run_test.go
@@ -17,6 +17,7 @@ func TestRun_StopsOnContextCancel(t *testing.T) {
 		emptyCheckList,
 		Delays{Up: 1 * time.Second, Down: 1 * time.Second},
 		nil,
+		status.BucketConfig{},
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -46,6 +47,7 @@ func TestRun_ProcessesChecks(t *testing.T) {
 		checkList,
 		Delays{Up: 10 * time.Millisecond, Down: 10 * time.Millisecond},
 		nil,
+		status.BucketConfig{},
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -65,6 +67,7 @@ func TestStop_StopsStatServer(t *testing.T) {
 		emptyCheckList,
 		Delays{Up: 1 * time.Second, Down: 1 * time.Second},
 		nil,
+		status.BucketConfig{},
 	)
 
 	ctx := t.Context()
@@ -84,6 +87,7 @@ func TestRun_StopsTimerOnContextCancel(t *testing.T) {
 		emptyCheckList,
 		Delays{Up: longDelay, Down: longDelay},
 		nil,
+		status.BucketConfig{},
 		0,
 	)
 

--- a/internal/logic/loop_test.go
+++ b/internal/logic/loop_test.go
@@ -112,7 +112,7 @@ func Test_ProcessCheck_PopulatesDownActionStatus(t *testing.T) {
 	loop.ProcessCheck(ctx, false)
 	report := loop.status.GenStatReport(nil)
 	require.NotNil(t, report.DownAction)
-	assert.Equal(t, uint64(0), report.DownAction.Iteration)
+	assert.Equal(t, uint32(0), report.DownAction.Iteration)
 	assert.False(t, report.DownAction.BackoffCapped)
 }
 

--- a/internal/logic/loop_test.go
+++ b/internal/logic/loop_test.go
@@ -5,13 +5,14 @@ import (
 	"time"
 
 	"github.com/hugoh/upd/internal/check"
+	"github.com/hugoh/upd/internal/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func emptyNewLoop() *Loop {
 	l := NewLoop()
-	l.Configure(nil, Delays{}, nil)
+	l.Configure(nil, Delays{}, nil, status.BucketConfig{})
 
 	return l
 }
@@ -19,13 +20,13 @@ func emptyNewLoop() *Loop {
 func TestConfigure_TrackerCreatedOnlyWithReports(t *testing.T) {
 	t.Run("no periods", func(t *testing.T) {
 		loop := NewLoop()
-		loop.Configure(nil, Delays{}, nil)
+		loop.Configure(nil, Delays{}, nil, status.BucketConfig{})
 		assert.Nil(t, loop.rollingTracker, "no tracker without reports")
 	})
 
 	t.Run("with periods", func(t *testing.T) {
 		loop := NewLoop()
-		loop.Configure(nil, Delays{}, nil, time.Minute, 5*time.Minute)
+		loop.Configure(nil, Delays{}, nil, status.BucketConfig{}, time.Minute, 5*time.Minute)
 		assert.NotNil(t, loop.rollingTracker, "tracker created when reports given")
 	})
 }
@@ -94,7 +95,7 @@ func Test_ProcessCheck_StatusChanged_DownStatus_StartsDownAction(t *testing.T) {
 
 func Test_ProcessCheck_PopulatesLoopStatus(t *testing.T) {
 	loop := NewLoop()
-	loop.Configure(nil, Delays{Up: time.Minute, Down: 30 * time.Second}, nil)
+	loop.Configure(nil, Delays{Up: time.Minute, Down: 30 * time.Second}, nil, status.BucketConfig{})
 
 	ctx := t.Context()
 
@@ -114,7 +115,7 @@ func Test_ProcessCheck_PopulatesLoopStatus(t *testing.T) {
 func Test_ProcessCheck_PopulatesDownActionStatus(t *testing.T) {
 	loop := NewLoop()
 	da := getTestDA()
-	loop.Configure(nil, Delays{Up: time.Minute, Down: 30 * time.Second}, da)
+	loop.Configure(nil, Delays{Up: time.Minute, Down: 30 * time.Second}, da, status.BucketConfig{})
 
 	ctx := t.Context()
 

--- a/internal/logic/loop_test.go
+++ b/internal/logic/loop_test.go
@@ -11,7 +11,7 @@ import (
 
 func emptyNewLoop() *Loop {
 	l := NewLoop()
-	l.Configure(nil, nil, nil)
+	l.Configure(nil, Delays{}, nil)
 
 	return l
 }
@@ -19,13 +19,13 @@ func emptyNewLoop() *Loop {
 func TestConfigure_TrackerCreatedOnlyWithReports(t *testing.T) {
 	t.Run("no periods", func(t *testing.T) {
 		loop := NewLoop()
-		loop.Configure(nil, nil, nil)
+		loop.Configure(nil, Delays{}, nil)
 		assert.Nil(t, loop.rollingTracker, "no tracker without reports")
 	})
 
 	t.Run("with periods", func(t *testing.T) {
 		loop := NewLoop()
-		loop.Configure(nil, nil, nil, time.Minute, 5*time.Minute)
+		loop.Configure(nil, Delays{}, nil, time.Minute, 5*time.Minute)
 		assert.NotNil(t, loop.rollingTracker, "tracker created when reports given")
 	})
 }
@@ -94,7 +94,7 @@ func Test_ProcessCheck_StatusChanged_DownStatus_StartsDownAction(t *testing.T) {
 
 func Test_ProcessCheck_PopulatesLoopStatus(t *testing.T) {
 	loop := NewLoop()
-	loop.Configure(nil, Delays{true: time.Minute, false: 30 * time.Second}, nil)
+	loop.Configure(nil, Delays{Up: time.Minute, Down: 30 * time.Second}, nil)
 
 	ctx := t.Context()
 
@@ -114,7 +114,7 @@ func Test_ProcessCheck_PopulatesLoopStatus(t *testing.T) {
 func Test_ProcessCheck_PopulatesDownActionStatus(t *testing.T) {
 	loop := NewLoop()
 	da := getTestDA()
-	loop.Configure(nil, Delays{true: time.Minute, false: 30 * time.Second}, da)
+	loop.Configure(nil, Delays{Up: time.Minute, Down: 30 * time.Second}, da)
 
 	ctx := t.Context()
 

--- a/internal/logic/loop_test.go
+++ b/internal/logic/loop_test.go
@@ -11,9 +11,23 @@ import (
 
 func emptyNewLoop() *Loop {
 	l := NewLoop()
-	l.Configure(nil, nil, nil, 0)
+	l.Configure(nil, nil, nil)
 
 	return l
+}
+
+func TestConfigure_TrackerCreatedOnlyWithReports(t *testing.T) {
+	t.Run("no periods", func(t *testing.T) {
+		loop := NewLoop()
+		loop.Configure(nil, nil, nil)
+		assert.Nil(t, loop.rollingTracker, "no tracker without reports")
+	})
+
+	t.Run("with periods", func(t *testing.T) {
+		loop := NewLoop()
+		loop.Configure(nil, nil, nil, time.Minute, 5*time.Minute)
+		assert.NotNil(t, loop.rollingTracker, "tracker created when reports given")
+	})
 }
 
 func Test_DownActionStartStop(t *testing.T) {
@@ -80,7 +94,7 @@ func Test_ProcessCheck_StatusChanged_DownStatus_StartsDownAction(t *testing.T) {
 
 func Test_ProcessCheck_PopulatesLoopStatus(t *testing.T) {
 	loop := NewLoop()
-	loop.Configure(nil, Delays{true: time.Minute, false: 30 * time.Second}, nil, 0)
+	loop.Configure(nil, Delays{true: time.Minute, false: 30 * time.Second}, nil)
 
 	ctx := t.Context()
 
@@ -100,7 +114,7 @@ func Test_ProcessCheck_PopulatesLoopStatus(t *testing.T) {
 func Test_ProcessCheck_PopulatesDownActionStatus(t *testing.T) {
 	loop := NewLoop()
 	da := getTestDA()
-	loop.Configure(nil, Delays{true: time.Minute, false: 30 * time.Second}, da, 0)
+	loop.Configure(nil, Delays{true: time.Minute, false: 30 * time.Second}, da)
 
 	ctx := t.Context()
 

--- a/internal/status/changetracker.go
+++ b/internal/status/changetracker.go
@@ -17,7 +17,7 @@ type StateChangeTracker struct {
 	head        *StateChange
 	tail        *StateChange
 	retention   time.Duration
-	updateCount uint64
+	updateCount uint32
 	lastUpdated time.Time
 	started     time.Time
 }

--- a/internal/status/changetracker_test.go
+++ b/internal/status/changetracker_test.go
@@ -45,7 +45,7 @@ func TestRecordChange_UpdatesCurrentTimeFields(t *testing.T) {
 	now := time.Now()
 	tracker.RecordChange(now, true)
 	assert.Equal(t, now, tracker.lastUpdated)
-	assert.Equal(t, uint64(1), tracker.updateCount)
+	assert.Equal(t, uint32(1), tracker.updateCount)
 }
 
 func TestRecordChange_HeadAndTailSetCorrectly(t *testing.T) {

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -6,11 +6,19 @@ import (
 	"time"
 )
 
+// probeBucket counts probe results within one bucket interval. Bucket start
+// times are not stored: they are derived from RollingProbeTracker.lastTime
+// and the bucket's distance from the newest bucket, keeping the ring buffer
+// at 8 bytes per bucket.
 type probeBucket struct {
-	timestamp time.Time
-	total     uint32
-	failed    uint32
+	total  uint32
+	failed uint32
 }
+
+// MaxBucketCount caps the ring buffer size regardless of configuration
+// (~800 KiB at 8 bytes per bucket). When a configuration would exceed it,
+// the bucket interval is enlarged instead.
+const MaxBucketCount = 100_000
 
 // RollingProbeTracker tracks probe success/failure rates within a rolling time
 // window using time-bucketed counters in a ring buffer. Thread-safe.
@@ -20,14 +28,19 @@ type RollingProbeTracker struct {
 	maxBuckets     int
 	buckets        []probeBucket
 	head           int
-	tail           int
 	count          int
+	lastTime       time.Time // start time of the newest bucket
 }
 
 // NewRollingProbeTracker creates a tracker that retains data for the given
-// duration using buckets of the given interval.
+// duration using buckets of the given interval, enlarged if needed to keep
+// the bucket count under MaxBucketCount.
 func NewRollingProbeTracker(retention, bucketInterval time.Duration) *RollingProbeTracker {
-	maxBuckets := max(int(retention/bucketInterval)+1, 1)
+	if minInterval := retention / (MaxBucketCount - 1); bucketInterval < minInterval {
+		bucketInterval = minInterval
+	}
+
+	maxBuckets := min(max(int(retention/bucketInterval)+1, 1), MaxBucketCount)
 
 	return &RollingProbeTracker{
 		bucketInterval: bucketInterval,
@@ -58,8 +71,7 @@ func (t *RollingProbeTracker) Record(failed bool) {
 	t.recordAt(time.Now())
 
 	if failed {
-		idx := (t.tail - 1 + t.maxBuckets) % t.maxBuckets
-		t.buckets[idx].failed++
+		t.buckets[t.newestIdx()].failed++
 	}
 }
 
@@ -74,64 +86,75 @@ func (t *RollingProbeTracker) Stats(since time.Duration, now time.Time) (int, in
 	}
 
 	cutoff := now.Add(-since)
+	oldest := t.lastTime.Add(-time.Duration(t.count-1) * t.bucketInterval)
+
+	skip := 0
+	if diff := cutoff.Sub(oldest); diff > 0 {
+		// Ceil: a bucket is included only if it starts at or after the cutoff.
+		skip = min(int((diff+t.bucketInterval-1)/t.bucketInterval), t.count)
+	}
 
 	var total, failed int
 
-	for i := range t.count {
-		idx := (t.head + i) % t.maxBuckets
-		b := t.buckets[idx]
-
-		if !b.timestamp.Before(cutoff) {
-			total += int(b.total)
-			failed += int(b.failed)
-		}
+	for i := skip; i < t.count; i++ {
+		bucket := t.buckets[(t.head+i)%t.maxBuckets]
+		total += int(bucket.total)
+		failed += int(bucket.failed)
 	}
 
 	return total, failed
 }
 
-// recordAt records a probe result at the given time. Must be called with the
-// lock held.
+// newestIdx returns the ring index of the newest bucket. Must be called with
+// the lock held and count > 0.
+func (t *RollingProbeTracker) newestIdx() int {
+	return (t.head + t.count - 1) % t.maxBuckets
+}
+
+// recordAt counts a probe at the given time. Must be called with the lock
+// held.
 func (t *RollingProbeTracker) recordAt(now time.Time) {
 	bucketTime := now.Truncate(t.bucketInterval)
 
-	if t.count == 0 {
-		t.buckets[t.tail] = probeBucket{timestamp: bucketTime, total: 1}
-		t.tail = (t.tail + 1) % t.maxBuckets
+	switch {
+	case t.count == 0:
+		t.head = 0
 		t.count = 1
+		t.lastTime = bucketTime
+		t.buckets[0] = probeBucket{}
+	case bucketTime.After(t.lastTime):
+		t.advanceTo(bucketTime)
+	default:
+		// Same bucket as the last record, or earlier (clock drift, which
+		// should never happen): count into the newest bucket.
+	}
+
+	t.buckets[t.newestIdx()].total++
+}
+
+// advanceTo appends empty buckets up to bucketTime, evicting the oldest ones
+// once the ring is full. Must be called with the lock held, count > 0, and
+// bucketTime after lastTime.
+func (t *RollingProbeTracker) advanceTo(bucketTime time.Time) {
+	steps := int(bucketTime.Sub(t.lastTime) / t.bucketInterval)
+	t.lastTime = bucketTime
+
+	if steps >= t.maxBuckets {
+		// The gap spans the whole window: drop everything.
+		t.head = 0
+		t.count = 1
+		t.buckets[0] = probeBucket{}
 
 		return
 	}
 
-	lastIdx := (t.tail - 1 + t.maxBuckets) % t.maxBuckets
-	lastTime := t.buckets[lastIdx].timestamp
-
-	if bucketTime.Equal(lastTime) {
-		t.buckets[lastIdx].total++
-
-		return
-	}
-
-	if bucketTime.After(lastTime) {
-		bi := t.bucketInterval
-
-		for nextTime := lastTime.Add(bi); !nextTime.After(bucketTime); nextTime = nextTime.Add(bi) {
-			if t.count == t.maxBuckets {
-				t.head = (t.head + 1) % t.maxBuckets
-				t.count--
-			}
-
-			t.buckets[t.tail] = probeBucket{timestamp: nextTime}
-			t.tail = (t.tail + 1) % t.maxBuckets
+	for range steps {
+		if t.count == t.maxBuckets {
+			t.buckets[t.head] = probeBucket{}
+			t.head = (t.head + 1) % t.maxBuckets
+		} else {
+			t.buckets[(t.head+t.count)%t.maxBuckets] = probeBucket{}
 			t.count++
 		}
-
-		lastIdx = (t.tail - 1 + t.maxBuckets) % t.maxBuckets
-		t.buckets[lastIdx].total++
-
-		return
 	}
-
-	// bucketTime before lastTime should never happen (clock drift guard)
-	t.buckets[lastIdx].total++
 }

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -1,6 +1,7 @@
 package status
 
 import (
+	"slices"
 	"sync"
 	"time"
 )
@@ -35,6 +36,10 @@ func NewRollingProbeTracker(retention, bucketInterval time.Duration) *RollingPro
 	}
 }
 
+// BucketIntervalDivisor controls bucket granularity relative to the shortest
+// report period; the rolling-window error is bounded to ~1/Divisor of it.
+const BucketIntervalDivisor = 10
+
 // BucketInterval returns the probe bucket interval to use for the given
 // report periods. Defaults to 1 minute when no periods are given.
 func BucketInterval(periods []time.Duration) time.Duration {
@@ -42,14 +47,7 @@ func BucketInterval(periods []time.Duration) time.Duration {
 		return time.Minute
 	}
 
-	minPeriod := periods[0]
-	for _, p := range periods[1:] {
-		if p < minPeriod {
-			minPeriod = p
-		}
-	}
-
-	return max(minPeriod, time.Second)
+	return max(slices.Min(periods)/BucketIntervalDivisor, time.Second)
 }
 
 // Record records a probe result.

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -5,8 +5,6 @@ import (
 	"time"
 )
 
-const bucketInterval = time.Minute
-
 type probeBucket struct {
 	timestamp time.Time
 	total     uint32
@@ -14,26 +12,44 @@ type probeBucket struct {
 }
 
 // RollingProbeTracker tracks probe success/failure rates within a rolling time
-// window using time-bucketed counters (1-minute buckets) in a ring buffer.
-// Thread-safe.
+// window using time-bucketed counters in a ring buffer. Thread-safe.
 type RollingProbeTracker struct {
-	mu         sync.Mutex
-	maxBuckets int
-	buckets    []probeBucket
-	head       int
-	tail       int
-	count      int
+	mu             sync.Mutex
+	bucketInterval time.Duration
+	maxBuckets     int
+	buckets        []probeBucket
+	head           int
+	tail           int
+	count          int
 }
 
 // NewRollingProbeTracker creates a tracker that retains data for the given
-// duration using 1-minute buckets.
-func NewRollingProbeTracker(retention time.Duration) *RollingProbeTracker {
+// duration using buckets of the given interval.
+func NewRollingProbeTracker(retention, bucketInterval time.Duration) *RollingProbeTracker {
 	maxBuckets := max(int(retention/bucketInterval)+1, 1)
 
 	return &RollingProbeTracker{
-		maxBuckets: maxBuckets,
-		buckets:    make([]probeBucket, maxBuckets),
+		bucketInterval: bucketInterval,
+		maxBuckets:     maxBuckets,
+		buckets:        make([]probeBucket, maxBuckets),
 	}
+}
+
+// BucketInterval returns the probe bucket interval to use for the given
+// report periods. Defaults to 1 minute when no periods are given.
+func BucketInterval(periods []time.Duration) time.Duration {
+	if len(periods) == 0 {
+		return time.Minute
+	}
+
+	minPeriod := periods[0]
+	for _, p := range periods[1:] {
+		if p < minPeriod {
+			minPeriod = p
+		}
+	}
+
+	return max(minPeriod, time.Second)
 }
 
 // Record records a probe result.
@@ -79,7 +95,7 @@ func (t *RollingProbeTracker) Stats(since time.Duration, now time.Time) (int, in
 // recordAt records a probe result at the given time. Must be called with the
 // lock held.
 func (t *RollingProbeTracker) recordAt(now time.Time) {
-	bucketTime := now.Truncate(bucketInterval)
+	bucketTime := now.Truncate(t.bucketInterval)
 
 	if t.count == 0 {
 		t.buckets[t.tail] = probeBucket{timestamp: bucketTime, total: 1}
@@ -99,7 +115,9 @@ func (t *RollingProbeTracker) recordAt(now time.Time) {
 	}
 
 	if bucketTime.After(lastTime) {
-		for nextTime := lastTime.Add(bucketInterval); !nextTime.After(bucketTime); nextTime = nextTime.Add(bucketInterval) {
+		bi := t.bucketInterval
+
+		for nextTime := lastTime.Add(bi); !nextTime.After(bucketTime); nextTime = nextTime.Add(bi) {
 			if t.count == t.maxBuckets {
 				t.head = (t.head + 1) % t.maxBuckets
 				t.count--

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -1,160 +1,203 @@
 package status
 
 import (
-	"slices"
+	"cmp"
 	"sync"
 	"time"
 )
 
 // probeBucket counts probe results within one bucket interval. Bucket start
-// times are not stored: they are derived from RollingProbeTracker.lastTime
-// and the bucket's distance from the newest bucket, keeping the ring buffer
-// at 8 bytes per bucket.
+// times are not stored: they are derived from the ring's lastTime and the
+// bucket's distance from the newest bucket, keeping rings at 8 bytes per
+// bucket.
 type probeBucket struct {
 	total  uint32
 	failed uint32
 }
 
-// MaxBucketCount caps the ring buffer size regardless of configuration
-// (~800 KiB at 8 bytes per bucket). When a configuration would exceed it,
-// the bucket interval is enlarged instead.
-const MaxBucketCount = 100_000
+const (
+	// DefaultBucketsMin is the default minimum number of buckets each report
+	// period is split into.
+	DefaultBucketsMin = 100
+	// DefaultBucketMaxSpan is the default maximum time span a single bucket
+	// aggregates.
+	DefaultBucketMaxSpan = 30 * time.Minute
+	// MinBucketInterval is the smallest bucket interval.
+	MinBucketInterval = time.Second
+	// MaxBucketsPerPeriod bounds the ring size for a single report period
+	// (~800 KiB at 8 bytes per bucket).
+	MaxBucketsPerPeriod = 100_000
+)
 
-// RollingProbeTracker tracks probe success/failure rates within a rolling time
-// window using time-bucketed counters in a ring buffer. Thread-safe.
+// BucketConfig tunes probe-stat bucket granularity. Zero values mean
+// defaults.
+type BucketConfig struct {
+	// Min is the minimum number of buckets a report period is split into.
+	Min int
+	// MaxSpan is the maximum time span a single bucket aggregates.
+	MaxSpan time.Duration
+}
+
+// Interval returns the bucket interval for the given report period:
+// period/Min, capped at MaxSpan and floored at MinBucketInterval.
+func (c BucketConfig) Interval(period time.Duration) time.Duration {
+	minBuckets := cmp.Or(c.Min, DefaultBucketsMin)
+	maxSpan := cmp.Or(c.MaxSpan, DefaultBucketMaxSpan)
+
+	interval := min(period/time.Duration(minBuckets), maxSpan)
+
+	return max(interval, MinBucketInterval)
+}
+
+// BucketCount returns the ring size needed to cover the given report period.
+func (c BucketConfig) BucketCount(period time.Duration) int {
+	return max(int(period/c.Interval(period))+1, 1)
+}
+
+// probeRing is a fixed-size ring of time-bucketed counters covering one
+// report period.
+type probeRing struct {
+	period   time.Duration
+	interval time.Duration
+	buckets  []probeBucket
+	head     int
+	count    int
+	lastTime time.Time // start time of the newest bucket
+}
+
+// RollingProbeTracker tracks probe success/failure rates per report period.
+// Each period gets its own ring of bucketed counters, so bucket granularity
+// is proportional to the period it serves instead of one global resolution
+// paying for the longest retention. Thread-safe.
 type RollingProbeTracker struct {
-	mu             sync.Mutex
-	bucketInterval time.Duration
-	maxBuckets     int
-	buckets        []probeBucket
-	head           int
-	count          int
-	lastTime       time.Time // start time of the newest bucket
+	mu    sync.Mutex
+	rings []*probeRing
 }
 
-// NewRollingProbeTracker creates a tracker that retains data for the given
-// duration using buckets of the given interval, enlarged if needed to keep
-// the bucket count under MaxBucketCount.
-func NewRollingProbeTracker(retention, bucketInterval time.Duration) *RollingProbeTracker {
-	if minInterval := retention / (MaxBucketCount - 1); bucketInterval < minInterval {
-		bucketInterval = minInterval
+// NewRollingProbeTracker creates a tracker with one ring per report period.
+func NewRollingProbeTracker(periods []time.Duration, cfg BucketConfig) *RollingProbeTracker {
+	rings := make([]*probeRing, 0, len(periods))
+
+	for _, period := range periods {
+		rings = append(rings, &probeRing{
+			period:   period,
+			interval: cfg.Interval(period),
+			buckets:  make([]probeBucket, cfg.BucketCount(period)),
+		})
 	}
 
-	maxBuckets := min(max(int(retention/bucketInterval)+1, 1), MaxBucketCount)
-
-	return &RollingProbeTracker{
-		bucketInterval: bucketInterval,
-		maxBuckets:     maxBuckets,
-		buckets:        make([]probeBucket, maxBuckets),
-	}
-}
-
-// BucketIntervalDivisor controls bucket granularity relative to the shortest
-// report period; the rolling-window error is bounded to ~1/Divisor of it.
-const BucketIntervalDivisor = 10
-
-// BucketInterval returns the probe bucket interval to use for the given
-// report periods. Defaults to 1 minute when no periods are given.
-func BucketInterval(periods []time.Duration) time.Duration {
-	if len(periods) == 0 {
-		return time.Minute
-	}
-
-	return max(slices.Min(periods)/BucketIntervalDivisor, time.Second)
+	return &RollingProbeTracker{rings: rings}
 }
 
 // Record records a probe result.
 func (t *RollingProbeTracker) Record(failed bool) {
+	now := time.Now()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.recordAt(time.Now())
+	for _, ring := range t.rings {
+		ring.recordAt(now)
 
-	if failed {
-		t.buckets[t.newestIdx()].failed++
+		if failed {
+			ring.buckets[ring.newestIdx()].failed++
+		}
 	}
 }
 
-// Stats returns (total, failed) probe results within the given duration
-// before now.
-func (t *RollingProbeTracker) Stats(since time.Duration, now time.Time) (int, int) {
+// Stats returns (total, failed) probe results within the given report period
+// before now. The period must be one of the configured report periods;
+// unknown periods report no data.
+func (t *RollingProbeTracker) Stats(period time.Duration, now time.Time) (int, int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if t.count == 0 {
-		return 0, 0
+	for _, ring := range t.rings {
+		if ring.period == period {
+			return ring.statsSince(now.Add(-period))
+		}
 	}
 
-	cutoff := now.Add(-since)
-	oldest := t.lastTime.Add(-time.Duration(t.count-1) * t.bucketInterval)
-
-	skip := 0
-	if diff := cutoff.Sub(oldest); diff > 0 {
-		// Ceil: a bucket is included only if it starts at or after the cutoff.
-		skip = min(int((diff+t.bucketInterval-1)/t.bucketInterval), t.count)
-	}
-
-	var total, failed int
-
-	for i := skip; i < t.count; i++ {
-		bucket := t.buckets[(t.head+i)%t.maxBuckets]
-		total += int(bucket.total)
-		failed += int(bucket.failed)
-	}
-
-	return total, failed
+	return 0, 0
 }
 
 // newestIdx returns the ring index of the newest bucket. Must be called with
-// the lock held and count > 0.
-func (t *RollingProbeTracker) newestIdx() int {
-	return (t.head + t.count - 1) % t.maxBuckets
+// the tracker lock held and count > 0.
+func (r *probeRing) newestIdx() int {
+	return (r.head + r.count - 1) % len(r.buckets)
 }
 
-// recordAt counts a probe at the given time. Must be called with the lock
-// held.
-func (t *RollingProbeTracker) recordAt(now time.Time) {
-	bucketTime := now.Truncate(t.bucketInterval)
+// recordAt counts a probe at the given time. Must be called with the tracker
+// lock held.
+func (r *probeRing) recordAt(now time.Time) {
+	bucketTime := now.Truncate(r.interval)
 
 	switch {
-	case t.count == 0:
-		t.head = 0
-		t.count = 1
-		t.lastTime = bucketTime
-		t.buckets[0] = probeBucket{}
-	case bucketTime.After(t.lastTime):
-		t.advanceTo(bucketTime)
+	case r.count == 0:
+		r.head = 0
+		r.count = 1
+		r.lastTime = bucketTime
+		r.buckets[0] = probeBucket{}
+	case bucketTime.After(r.lastTime):
+		r.advanceTo(bucketTime)
 	default:
 		// Same bucket as the last record, or earlier (clock drift, which
 		// should never happen): count into the newest bucket.
 	}
 
-	t.buckets[t.newestIdx()].total++
+	r.buckets[r.newestIdx()].total++
 }
 
 // advanceTo appends empty buckets up to bucketTime, evicting the oldest ones
-// once the ring is full. Must be called with the lock held, count > 0, and
-// bucketTime after lastTime.
-func (t *RollingProbeTracker) advanceTo(bucketTime time.Time) {
-	steps := int(bucketTime.Sub(t.lastTime) / t.bucketInterval)
-	t.lastTime = bucketTime
+// once the ring is full. Must be called with the tracker lock held,
+// count > 0, and bucketTime after lastTime.
+func (r *probeRing) advanceTo(bucketTime time.Time) {
+	maxBuckets := len(r.buckets)
+	steps := int(bucketTime.Sub(r.lastTime) / r.interval)
+	r.lastTime = bucketTime
 
-	if steps >= t.maxBuckets {
-		// The gap spans the whole window: drop everything.
-		t.head = 0
-		t.count = 1
-		t.buckets[0] = probeBucket{}
+	if steps >= maxBuckets {
+		// The gap spans the whole ring: drop everything.
+		r.head = 0
+		r.count = 1
+		r.buckets[0] = probeBucket{}
 
 		return
 	}
 
 	for range steps {
-		if t.count == t.maxBuckets {
-			t.buckets[t.head] = probeBucket{}
-			t.head = (t.head + 1) % t.maxBuckets
+		if r.count == maxBuckets {
+			r.buckets[r.head] = probeBucket{}
+			r.head = (r.head + 1) % maxBuckets
 		} else {
-			t.buckets[(t.head+t.count)%t.maxBuckets] = probeBucket{}
-			t.count++
+			r.buckets[(r.head+r.count)%maxBuckets] = probeBucket{}
+			r.count++
 		}
 	}
+}
+
+// statsSince sums the buckets that start at or after cutoff. Must be called
+// with the tracker lock held.
+func (r *probeRing) statsSince(cutoff time.Time) (int, int) {
+	if r.count == 0 {
+		return 0, 0
+	}
+
+	oldest := r.lastTime.Add(-time.Duration(r.count-1) * r.interval)
+
+	skip := 0
+	if diff := cutoff.Sub(oldest); diff > 0 {
+		// Ceil: a bucket is included only if it starts at or after the cutoff.
+		skip = min(int((diff+r.interval-1)/r.interval), r.count)
+	}
+
+	var total, failed int
+
+	for i := skip; i < r.count; i++ {
+		bucket := r.buckets[(r.head+i)%len(r.buckets)]
+		total += int(bucket.total)
+		failed += int(bucket.failed)
+	}
+
+	return total, failed
 }

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -1,0 +1,121 @@
+package status
+
+import (
+	"sync"
+	"time"
+)
+
+const bucketInterval = time.Minute
+
+type probeBucket struct {
+	timestamp time.Time
+	total     uint32
+	failed    uint32
+}
+
+// RollingProbeTracker tracks probe success/failure rates within a rolling time
+// window using time-bucketed counters (1-minute buckets) in a ring buffer.
+// Thread-safe.
+type RollingProbeTracker struct {
+	mu         sync.Mutex
+	maxBuckets int
+	buckets    []probeBucket
+	head       int
+	tail       int
+	count      int
+}
+
+// NewRollingProbeTracker creates a tracker that retains data for the given
+// duration using 1-minute buckets.
+func NewRollingProbeTracker(retention time.Duration) *RollingProbeTracker {
+	maxBuckets := max(int(retention/bucketInterval)+1, 1)
+
+	return &RollingProbeTracker{
+		maxBuckets: maxBuckets,
+		buckets:    make([]probeBucket, maxBuckets),
+	}
+}
+
+// Record records a probe result.
+func (t *RollingProbeTracker) Record(failed bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.recordAt(time.Now())
+
+	if failed {
+		idx := (t.tail - 1 + t.maxBuckets) % t.maxBuckets
+		t.buckets[idx].failed++
+	}
+}
+
+// Stats returns (total, failed) probe results within the given duration
+// before now.
+func (t *RollingProbeTracker) Stats(since time.Duration, now time.Time) (int, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.count == 0 {
+		return 0, 0
+	}
+
+	cutoff := now.Add(-since)
+
+	var total, failed int
+
+	for i := range t.count {
+		idx := (t.head + i) % t.maxBuckets
+		b := t.buckets[idx]
+
+		if !b.timestamp.Before(cutoff) {
+			total += int(b.total)
+			failed += int(b.failed)
+		}
+	}
+
+	return total, failed
+}
+
+// recordAt records a probe result at the given time. Must be called with the
+// lock held.
+func (t *RollingProbeTracker) recordAt(now time.Time) {
+	bucketTime := now.Truncate(bucketInterval)
+
+	if t.count == 0 {
+		t.buckets[t.tail] = probeBucket{timestamp: bucketTime, total: 1}
+		t.tail = (t.tail + 1) % t.maxBuckets
+		t.count = 1
+
+		return
+	}
+
+	lastIdx := (t.tail - 1 + t.maxBuckets) % t.maxBuckets
+	lastTime := t.buckets[lastIdx].timestamp
+
+	if bucketTime.Equal(lastTime) {
+		t.buckets[lastIdx].total++
+
+		return
+	}
+
+	if bucketTime.After(lastTime) {
+		for nextTime := lastTime.Add(bucketInterval); !nextTime.After(bucketTime); nextTime = nextTime.Add(bucketInterval) {
+			if t.count == t.maxBuckets {
+				t.head = (t.head + 1) % t.maxBuckets
+				t.count--
+			}
+
+			t.buckets[t.tail] = probeBucket{timestamp: nextTime}
+			t.tail = (t.tail + 1) % t.maxBuckets
+			t.count++
+		}
+
+		lastIdx = (t.tail - 1 + t.maxBuckets) % t.maxBuckets
+		t.buckets[lastIdx].total++
+
+		return
+	}
+
+	// bucketTime before lastTime should never happen (clock drift guard)
+	t.buckets[lastIdx].total++
+}

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -199,6 +199,32 @@ func TestRollingProbeTracker_SubMinuteBucket(t *testing.T) {
 	assert.Equal(t, 0, failed)
 }
 
+func TestNewRollingProbeTracker_CapsBucketCount(t *testing.T) {
+	// 7 days at 1s buckets would be 604,801 buckets; the cap enlarges the
+	// interval instead.
+	tracker := NewRollingProbeTracker(7*24*time.Hour, time.Second)
+
+	assert.LessOrEqual(t, tracker.maxBuckets, MaxBucketCount)
+	assert.Len(t, tracker.buckets, tracker.maxBuckets)
+	assert.Greater(t, tracker.bucketInterval, time.Second)
+}
+
+func TestRollingProbeTracker_LongGapResets(t *testing.T) {
+	now := startOfThisMinute()
+	tracker := NewRollingProbeTracker(5*time.Minute, time.Minute)
+
+	tracker.mu.Lock()
+	tracker.recordAt(now)
+	tracker.recordAt(now.Add(time.Minute))
+	// Gap longer than the whole retention window.
+	tracker.recordAt(now.Add(24 * time.Hour))
+	tracker.mu.Unlock()
+
+	total, failed := tracker.Stats(time.Hour, now.Add(24*time.Hour))
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 0, failed)
+}
+
 func TestNewRollingProbeTracker_ZeroRetention(t *testing.T) {
 	tracker := NewRollingProbeTracker(0, time.Minute)
 	assert.NotNil(t, tracker)

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -1,0 +1,120 @@
+package status
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func startOfThisMinute() time.Time {
+	return time.Now().Truncate(time.Minute)
+}
+
+func TestRollingProbeTracker_Record(t *testing.T) {
+	now := startOfThisMinute()
+	tracker := NewRollingProbeTracker(time.Hour)
+
+	for range 3 {
+		tracker.Record(false)
+	}
+
+	total, failed := tracker.Stats(time.Hour, now.Add(time.Minute))
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_RecordFailed(t *testing.T) {
+	tracker := NewRollingProbeTracker(time.Hour)
+
+	tracker.Record(false)
+	tracker.Record(true)
+	tracker.Record(false)
+
+	total, failed := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 1, failed)
+}
+
+func TestRollingProbeTracker_Empty(t *testing.T) {
+	tracker := NewRollingProbeTracker(time.Hour)
+
+	total, failed := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 0, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_OutsideWindow(t *testing.T) {
+	now := startOfThisMinute()
+	tracker := NewRollingProbeTracker(time.Hour)
+
+	tracker.Record(false)
+
+	total, failed := tracker.Stats(time.Nanosecond, now.Add(time.Hour))
+	assert.Equal(t, 0, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_BucketAdvancement(t *testing.T) {
+	now := startOfThisMinute()
+	tracker := NewRollingProbeTracker(time.Hour)
+
+	tracker.mu.Lock()
+	tracker.recordAt(now)                      // bucket 1
+	tracker.recordAt(now.Add(2 * time.Minute)) // bucket 3 (bucket 2 is empty gap)
+	tracker.mu.Unlock()
+
+	total, failed := tracker.Stats(time.Hour, now.Add(3*time.Minute))
+	assert.Equal(t, 2, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_WrapAround(t *testing.T) {
+	now := startOfThisMinute()
+	tracker := NewRollingProbeTracker(5 * time.Minute)
+	// maxBuckets = 5/1 + 1 = 6
+
+	tracker.mu.Lock()
+
+	for range 20 {
+		tracker.recordAt(now)
+		now = now.Add(time.Minute)
+	}
+
+	tracker.mu.Unlock()
+
+	// After 20 minutes of 1-min buckets with maxBuckets=6, only 6 remain
+	total, _ := tracker.Stats(time.Hour, now)
+	assert.Equal(t, 6, total)
+}
+
+func TestRollingProbeTracker_ConcurrentAccess(t *testing.T) {
+	tracker := NewRollingProbeTracker(time.Hour)
+
+	var wg sync.WaitGroup
+
+	for range 10 {
+		wg.Go(func() {
+			for range 100 {
+				tracker.Record(true)
+			}
+		})
+	}
+
+	wg.Wait()
+
+	total, failed := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 1000, total)
+	assert.Equal(t, 1000, failed)
+}
+
+func TestNewRollingProbeTracker_ZeroRetention(t *testing.T) {
+	tracker := NewRollingProbeTracker(0)
+	assert.NotNil(t, tracker)
+
+	tracker.Record(false)
+	total, failed := tracker.Stats(time.Minute, time.Now())
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 0, failed)
+}

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -12,24 +12,44 @@ func startOfThisMinute() time.Time {
 	return time.Now().Truncate(time.Minute)
 }
 
-func TestBucketInterval_Defaults(t *testing.T) {
-	assert.Equal(t, time.Minute, BucketInterval(nil))
-	assert.Equal(t, time.Minute, BucketInterval([]time.Duration{}))
+// newSingleRingTracker creates a tracker with one ring for the given period
+// and bucket interval.
+func newSingleRingTracker(period, interval time.Duration) *RollingProbeTracker {
+	return NewRollingProbeTracker(
+		[]time.Duration{period},
+		BucketConfig{Min: int(period / interval)},
+	)
 }
 
-func TestBucketInterval_FromPeriods(t *testing.T) {
-	assert.Equal(
-		t,
-		1500*time.Millisecond,
-		BucketInterval([]time.Duration{time.Minute, 15 * time.Second, 5 * time.Minute}),
-	)
-	assert.Equal(t, time.Second, BucketInterval([]time.Duration{100 * time.Millisecond}))
-	assert.Equal(t, 6*time.Minute, BucketInterval([]time.Duration{time.Hour, 24 * time.Hour}))
+func TestBucketConfig_Interval_Defaults(t *testing.T) {
+	var cfg BucketConfig
+
+	assert.Equal(t, time.Second, cfg.Interval(time.Minute), "floored at 1s")
+	assert.Equal(t, 9*time.Second, cfg.Interval(15*time.Minute), "period/100")
+	assert.Equal(t, 36*time.Second, cfg.Interval(time.Hour), "period/100")
+	assert.Equal(t, 864*time.Second, cfg.Interval(24*time.Hour), "period/100")
+	assert.Equal(t, 30*time.Minute, cfg.Interval(168*time.Hour), "capped at maxSpan")
+}
+
+func TestBucketConfig_Interval_Custom(t *testing.T) {
+	cfg := BucketConfig{Min: 10, MaxSpan: time.Hour}
+
+	assert.Equal(t, 6*time.Second, cfg.Interval(time.Minute))
+	assert.Equal(t, time.Hour, cfg.Interval(168*time.Hour))
+}
+
+func TestBucketConfig_BucketCount(t *testing.T) {
+	var cfg BucketConfig
+
+	assert.Equal(t, 61, cfg.BucketCount(time.Minute), "1s buckets")
+	assert.Equal(t, 101, cfg.BucketCount(time.Hour), "period/100 buckets")
+	assert.Equal(t, 337, cfg.BucketCount(168*time.Hour), "30m buckets")
+	assert.Equal(t, 1, cfg.BucketCount(0), "degenerate period")
 }
 
 func TestRollingProbeTracker_Record(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
+	tracker := newSingleRingTracker(time.Hour, time.Minute)
 
 	for range 3 {
 		tracker.Record(false)
@@ -41,7 +61,7 @@ func TestRollingProbeTracker_Record(t *testing.T) {
 }
 
 func TestRollingProbeTracker_RecordFailed(t *testing.T) {
-	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
+	tracker := newSingleRingTracker(time.Hour, time.Minute)
 
 	tracker.Record(false)
 	tracker.Record(true)
@@ -53,7 +73,27 @@ func TestRollingProbeTracker_RecordFailed(t *testing.T) {
 }
 
 func TestRollingProbeTracker_Empty(t *testing.T) {
-	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
+	tracker := newSingleRingTracker(time.Hour, time.Minute)
+
+	total, failed := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 0, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_UnknownPeriod(t *testing.T) {
+	tracker := newSingleRingTracker(time.Hour, time.Minute)
+
+	tracker.Record(false)
+
+	total, failed := tracker.Stats(2*time.Hour, time.Now())
+	assert.Equal(t, 0, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_NoPeriods(t *testing.T) {
+	tracker := NewRollingProbeTracker(nil, BucketConfig{})
+
+	tracker.Record(false)
 
 	total, failed := tracker.Stats(time.Hour, time.Now())
 	assert.Equal(t, 0, total)
@@ -62,22 +102,24 @@ func TestRollingProbeTracker_Empty(t *testing.T) {
 
 func TestRollingProbeTracker_OutsideWindow(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
+	tracker := newSingleRingTracker(time.Hour, time.Minute)
 
-	tracker.Record(false)
+	tracker.mu.Lock()
+	tracker.rings[0].recordAt(now)
+	tracker.mu.Unlock()
 
-	total, failed := tracker.Stats(time.Nanosecond, now.Add(time.Hour))
+	total, failed := tracker.Stats(time.Hour, now.Add(2*time.Hour))
 	assert.Equal(t, 0, total)
 	assert.Equal(t, 0, failed)
 }
 
 func TestRollingProbeTracker_BucketAdvancement(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
+	tracker := newSingleRingTracker(time.Hour, time.Minute)
 
 	tracker.mu.Lock()
-	tracker.recordAt(now)                      // bucket 1
-	tracker.recordAt(now.Add(2 * time.Minute)) // bucket 3 (bucket 2 is empty gap)
+	tracker.rings[0].recordAt(now)                      // bucket 1
+	tracker.rings[0].recordAt(now.Add(2 * time.Minute)) // bucket 3 (bucket 2 is empty gap)
 	tracker.mu.Unlock()
 
 	total, failed := tracker.Stats(time.Hour, now.Add(3*time.Minute))
@@ -87,25 +129,71 @@ func TestRollingProbeTracker_BucketAdvancement(t *testing.T) {
 
 func TestRollingProbeTracker_WrapAround(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(5*time.Minute, time.Minute)
-	// maxBuckets = 5/1 + 1 = 6
+	tracker := newSingleRingTracker(5*time.Minute, time.Minute)
+	// buckets = 5/1 + 1 = 6
 
 	tracker.mu.Lock()
 
 	for range 20 {
-		tracker.recordAt(now)
+		tracker.rings[0].recordAt(now)
 		now = now.Add(time.Minute)
+	}
+
+	// After 20 minutes of 1-min buckets with 6 buckets, only 6 remain even
+	// for a cutoff far in the past.
+	total, _ := tracker.rings[0].statsSince(now.Add(-time.Hour))
+	tracker.mu.Unlock()
+
+	assert.Equal(t, 6, total)
+
+	// The 5m report window itself covers the 5 newest buckets.
+	total, _ = tracker.Stats(5*time.Minute, now)
+	assert.Equal(t, 5, total)
+}
+
+func TestRollingProbeTracker_LongGapResets(t *testing.T) {
+	now := startOfThisMinute()
+	tracker := newSingleRingTracker(5*time.Minute, time.Minute)
+
+	tracker.mu.Lock()
+	tracker.rings[0].recordAt(now)
+	tracker.rings[0].recordAt(now.Add(time.Minute))
+	// Gap longer than the whole ring.
+	tracker.rings[0].recordAt(now.Add(24 * time.Hour))
+	tracker.mu.Unlock()
+
+	total, failed := tracker.Stats(5*time.Minute, now.Add(24*time.Hour))
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_PerPeriodGranularity(t *testing.T) {
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	tracker := NewRollingProbeTracker(
+		[]time.Duration{time.Minute, time.Hour},
+		BucketConfig{},
+	)
+
+	tracker.mu.Lock()
+
+	for _, ring := range tracker.rings {
+		ring.recordAt(base)
+		ring.recordAt(base.Add(2 * time.Minute))
 	}
 
 	tracker.mu.Unlock()
 
-	// After 20 minutes of 1-min buckets with maxBuckets=6, only 6 remain
-	total, _ := tracker.Stats(time.Hour, now)
-	assert.Equal(t, 6, total)
+	// The 1m window only sees the most recent probe.
+	total, _ := tracker.Stats(time.Minute, base.Add(2*time.Minute))
+	assert.Equal(t, 1, total)
+
+	// The 1h window sees both.
+	total, _ = tracker.Stats(time.Hour, base.Add(2*time.Minute))
+	assert.Equal(t, 2, total)
 }
 
 func TestRollingProbeTracker_ConcurrentAccess(t *testing.T) {
-	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
+	tracker := newSingleRingTracker(time.Hour, time.Minute)
 
 	var wg sync.WaitGroup
 
@@ -125,112 +213,49 @@ func TestRollingProbeTracker_ConcurrentAccess(t *testing.T) {
 }
 
 func TestRollingProbeTracker_AlignedWindow(t *testing.T) {
-	bi := 5 * time.Second
-	tracker := NewRollingProbeTracker(time.Hour, bi)
+	tracker := newSingleRingTracker(time.Hour, 5*time.Second)
 
 	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	tracker.mu.Lock()
 	// Bucket [12:00:00, 12:00:05)
-	tracker.recordAt(base.Add(4 * time.Second))
+	tracker.rings[0].recordAt(base.Add(4 * time.Second))
 	// Bucket [12:00:05, 12:00:10)
-	tracker.recordAt(base.Add(9 * time.Second))
+	tracker.rings[0].recordAt(base.Add(9 * time.Second))
 	tracker.mu.Unlock()
 
-	// Stats for last 15s from 12:00:20 → cutoff = 12:00:05 (bucket boundary)
-	total, failed := tracker.Stats(15*time.Second, base.Add(20*time.Second))
+	// 1h window from 12:55:05 → cutoff = 12:00:05 (later bucket boundary)
+	total, failed := tracker.rings[0].statsSince(base.Add(5 * time.Second))
 	assert.Equal(t, 1, total)
 	assert.Equal(t, 0, failed)
 
-	// Stats for last 20s from 12:00:20 → cutoff = 12:00:00 (bucket boundary)
-	total, failed = tracker.Stats(20*time.Second, base.Add(20*time.Second))
+	// Cutoff = 12:00:00 (first bucket boundary): both included
+	total, failed = tracker.rings[0].statsSince(base)
 	assert.Equal(t, 2, total)
 	assert.Equal(t, 0, failed)
 }
 
 func TestRollingProbeTracker_NonAlignedWindow(t *testing.T) {
-	bi := 5 * time.Second
-	tracker := NewRollingProbeTracker(time.Hour, bi)
+	tracker := newSingleRingTracker(time.Hour, 5*time.Second)
 
 	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	tracker.mu.Lock()
 	// Bucket [12:00:00, 12:00:05)
-	tracker.recordAt(base.Add(4 * time.Second))
+	tracker.rings[0].recordAt(base.Add(4 * time.Second))
 	// Bucket [12:00:05, 12:00:10)
-	tracker.recordAt(base.Add(6 * time.Second))
+	tracker.rings[0].recordAt(base.Add(6 * time.Second))
 	tracker.mu.Unlock()
 
-	// Stats for last 17s from 12:00:20 → cutoff = 12:00:03 (middle of first bucket)
-	// Bucket [12:00:00, 12:00:05): timestamp=12:00:00 < 12:00:03 → excluded
-	// Bucket [12:00:05, 12:00:10): timestamp=12:00:05 >= 12:00:03 → included
-	// total = 1 (the probe at 12:00:06)
-	total, failed := tracker.Stats(17*time.Second, base.Add(20*time.Second))
-	assert.Equal(t, 1, total)
-	assert.Equal(t, 0, failed)
-}
-
-func TestRollingProbeTracker_SubMinuteBucket(t *testing.T) {
-	bi := 5 * time.Second
-	tracker := NewRollingProbeTracker(time.Hour, bi)
-
-	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-
-	tracker.mu.Lock()
-	// Bucket [12:00:00, 12:00:05)
-	tracker.recordAt(base.Add(1 * time.Second))
-	tracker.recordAt(base.Add(3 * time.Second))
-	// Bucket [12:00:05, 12:00:10)
-	tracker.recordAt(base.Add(7 * time.Second))
-	tracker.mu.Unlock()
-
-	// Stats for last 5s from 12:00:09 → cutoff = 12:00:04
-	// Bucket [12:00:00, 12:00:05): timestamp=12:00:00 < 12:00:04 → excluded
-	// Bucket [12:00:05, 12:00:10): timestamp=12:00:05 >= 12:00:04 → included
-	total, failed := tracker.Stats(5*time.Second, base.Add(9*time.Second))
+	// Cutoff = 12:00:03 (middle of first bucket):
+	// Bucket [12:00:00, 12:00:05): starts before cutoff → excluded
+	// Bucket [12:00:05, 12:00:10): starts at or after cutoff → included
+	total, failed := tracker.rings[0].statsSince(base.Add(3 * time.Second))
 	assert.Equal(t, 1, total)
 	assert.Equal(t, 0, failed)
 
-	// Stats for last 10s from 12:00:09 → cutoff = 11:59:59
-	// Bucket [12:00:00, 12:00:05): timestamp=12:00:00 >= 11:59:59 → included
-	// Bucket [12:00:05, 12:00:10): timestamp=12:00:05 >= 11:59:59 → included
-	total, failed = tracker.Stats(10*time.Second, base.Add(9*time.Second))
-	assert.Equal(t, 3, total)
-	assert.Equal(t, 0, failed)
-}
-
-func TestNewRollingProbeTracker_CapsBucketCount(t *testing.T) {
-	// 7 days at 1s buckets would be 604,801 buckets; the cap enlarges the
-	// interval instead.
-	tracker := NewRollingProbeTracker(7*24*time.Hour, time.Second)
-
-	assert.LessOrEqual(t, tracker.maxBuckets, MaxBucketCount)
-	assert.Len(t, tracker.buckets, tracker.maxBuckets)
-	assert.Greater(t, tracker.bucketInterval, time.Second)
-}
-
-func TestRollingProbeTracker_LongGapResets(t *testing.T) {
-	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(5*time.Minute, time.Minute)
-
-	tracker.mu.Lock()
-	tracker.recordAt(now)
-	tracker.recordAt(now.Add(time.Minute))
-	// Gap longer than the whole retention window.
-	tracker.recordAt(now.Add(24 * time.Hour))
-	tracker.mu.Unlock()
-
-	total, failed := tracker.Stats(time.Hour, now.Add(24*time.Hour))
-	assert.Equal(t, 1, total)
-	assert.Equal(t, 0, failed)
-}
-
-func TestNewRollingProbeTracker_ZeroRetention(t *testing.T) {
-	tracker := NewRollingProbeTracker(0, time.Minute)
-	assert.NotNil(t, tracker)
-
-	tracker.Record(false)
-	total, failed := tracker.Stats(time.Minute, time.Now())
-	assert.Equal(t, 1, total)
+	// Cutoff = 11:59:59: both buckets included
+	total, failed = tracker.rings[0].statsSince(base.Add(-time.Second))
+	assert.Equal(t, 2, total)
 	assert.Equal(t, 0, failed)
 }

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -12,9 +12,23 @@ func startOfThisMinute() time.Time {
 	return time.Now().Truncate(time.Minute)
 }
 
+func TestBucketInterval_Defaults(t *testing.T) {
+	assert.Equal(t, time.Minute, BucketInterval(nil))
+	assert.Equal(t, time.Minute, BucketInterval([]time.Duration{}))
+}
+
+func TestBucketInterval_FromPeriods(t *testing.T) {
+	assert.Equal(
+		t,
+		15*time.Second,
+		BucketInterval([]time.Duration{time.Minute, 15 * time.Second, 5 * time.Minute}),
+	)
+	assert.Equal(t, time.Second, BucketInterval([]time.Duration{100 * time.Millisecond}))
+}
+
 func TestRollingProbeTracker_Record(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(time.Hour)
+	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
 
 	for range 3 {
 		tracker.Record(false)
@@ -26,7 +40,7 @@ func TestRollingProbeTracker_Record(t *testing.T) {
 }
 
 func TestRollingProbeTracker_RecordFailed(t *testing.T) {
-	tracker := NewRollingProbeTracker(time.Hour)
+	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
 
 	tracker.Record(false)
 	tracker.Record(true)
@@ -38,7 +52,7 @@ func TestRollingProbeTracker_RecordFailed(t *testing.T) {
 }
 
 func TestRollingProbeTracker_Empty(t *testing.T) {
-	tracker := NewRollingProbeTracker(time.Hour)
+	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
 
 	total, failed := tracker.Stats(time.Hour, time.Now())
 	assert.Equal(t, 0, total)
@@ -47,7 +61,7 @@ func TestRollingProbeTracker_Empty(t *testing.T) {
 
 func TestRollingProbeTracker_OutsideWindow(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(time.Hour)
+	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
 
 	tracker.Record(false)
 
@@ -58,7 +72,7 @@ func TestRollingProbeTracker_OutsideWindow(t *testing.T) {
 
 func TestRollingProbeTracker_BucketAdvancement(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(time.Hour)
+	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
 
 	tracker.mu.Lock()
 	tracker.recordAt(now)                      // bucket 1
@@ -72,7 +86,7 @@ func TestRollingProbeTracker_BucketAdvancement(t *testing.T) {
 
 func TestRollingProbeTracker_WrapAround(t *testing.T) {
 	now := startOfThisMinute()
-	tracker := NewRollingProbeTracker(5 * time.Minute)
+	tracker := NewRollingProbeTracker(5*time.Minute, time.Minute)
 	// maxBuckets = 5/1 + 1 = 6
 
 	tracker.mu.Lock()
@@ -90,7 +104,7 @@ func TestRollingProbeTracker_WrapAround(t *testing.T) {
 }
 
 func TestRollingProbeTracker_ConcurrentAccess(t *testing.T) {
-	tracker := NewRollingProbeTracker(time.Hour)
+	tracker := NewRollingProbeTracker(time.Hour, time.Minute)
 
 	var wg sync.WaitGroup
 
@@ -109,8 +123,83 @@ func TestRollingProbeTracker_ConcurrentAccess(t *testing.T) {
 	assert.Equal(t, 1000, failed)
 }
 
+func TestRollingProbeTracker_AlignedWindow(t *testing.T) {
+	bi := 5 * time.Second
+	tracker := NewRollingProbeTracker(time.Hour, bi)
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tracker.mu.Lock()
+	// Bucket [12:00:00, 12:00:05)
+	tracker.recordAt(base.Add(4 * time.Second))
+	// Bucket [12:00:05, 12:00:10)
+	tracker.recordAt(base.Add(9 * time.Second))
+	tracker.mu.Unlock()
+
+	// Stats for last 15s from 12:00:20 → cutoff = 12:00:05 (bucket boundary)
+	total, failed := tracker.Stats(15*time.Second, base.Add(20*time.Second))
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 0, failed)
+
+	// Stats for last 20s from 12:00:20 → cutoff = 12:00:00 (bucket boundary)
+	total, failed = tracker.Stats(20*time.Second, base.Add(20*time.Second))
+	assert.Equal(t, 2, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_NonAlignedWindow(t *testing.T) {
+	bi := 5 * time.Second
+	tracker := NewRollingProbeTracker(time.Hour, bi)
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tracker.mu.Lock()
+	// Bucket [12:00:00, 12:00:05)
+	tracker.recordAt(base.Add(4 * time.Second))
+	// Bucket [12:00:05, 12:00:10)
+	tracker.recordAt(base.Add(6 * time.Second))
+	tracker.mu.Unlock()
+
+	// Stats for last 17s from 12:00:20 → cutoff = 12:00:03 (middle of first bucket)
+	// Bucket [12:00:00, 12:00:05): timestamp=12:00:00 < 12:00:03 → excluded
+	// Bucket [12:00:05, 12:00:10): timestamp=12:00:05 >= 12:00:03 → included
+	// total = 1 (the probe at 12:00:06)
+	total, failed := tracker.Stats(17*time.Second, base.Add(20*time.Second))
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 0, failed)
+}
+
+func TestRollingProbeTracker_SubMinuteBucket(t *testing.T) {
+	bi := 5 * time.Second
+	tracker := NewRollingProbeTracker(time.Hour, bi)
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tracker.mu.Lock()
+	// Bucket [12:00:00, 12:00:05)
+	tracker.recordAt(base.Add(1 * time.Second))
+	tracker.recordAt(base.Add(3 * time.Second))
+	// Bucket [12:00:05, 12:00:10)
+	tracker.recordAt(base.Add(7 * time.Second))
+	tracker.mu.Unlock()
+
+	// Stats for last 5s from 12:00:09 → cutoff = 12:00:04
+	// Bucket [12:00:00, 12:00:05): timestamp=12:00:00 < 12:00:04 → excluded
+	// Bucket [12:00:05, 12:00:10): timestamp=12:00:05 >= 12:00:04 → included
+	total, failed := tracker.Stats(5*time.Second, base.Add(9*time.Second))
+	assert.Equal(t, 1, total)
+	assert.Equal(t, 0, failed)
+
+	// Stats for last 10s from 12:00:09 → cutoff = 11:59:59
+	// Bucket [12:00:00, 12:00:05): timestamp=12:00:00 >= 11:59:59 → included
+	// Bucket [12:00:05, 12:00:10): timestamp=12:00:05 >= 11:59:59 → included
+	total, failed = tracker.Stats(10*time.Second, base.Add(9*time.Second))
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 0, failed)
+}
+
 func TestNewRollingProbeTracker_ZeroRetention(t *testing.T) {
-	tracker := NewRollingProbeTracker(0)
+	tracker := NewRollingProbeTracker(0, time.Minute)
 	assert.NotNil(t, tracker)
 
 	tracker.Record(false)

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -20,10 +20,11 @@ func TestBucketInterval_Defaults(t *testing.T) {
 func TestBucketInterval_FromPeriods(t *testing.T) {
 	assert.Equal(
 		t,
-		15*time.Second,
+		1500*time.Millisecond,
 		BucketInterval([]time.Duration{time.Minute, 15 * time.Second, 5 * time.Minute}),
 	)
 	assert.Equal(t, time.Second, BucketInterval([]time.Duration{100 * time.Millisecond}))
+	assert.Equal(t, 6*time.Minute, BucketInterval([]time.Duration{time.Hour, 24 * time.Hour}))
 }
 
 func TestRollingProbeTracker_Record(t *testing.T) {

--- a/internal/status/report.go
+++ b/internal/status/report.go
@@ -10,11 +10,14 @@ type ReportByPeriod struct {
 	Period       ReadableDuration `json:"period"`
 	Availability ReadablePercent  `json:"availability"`
 	Downtime     ReadableDuration `json:"downTime"`
+	TotalProbes  int              `json:"totalProbes,omitempty"`
+	FailedProbes int              `json:"failedProbes,omitempty"`
+	FailureRate  ReadablePercent  `json:"failureRate,omitempty"`
 }
 
 // DownActionStatus contains the current state of the down action loop.
 type DownActionStatus struct {
-	Iteration     uint64           `json:"iteration"`
+	Iteration     uint32           `json:"iteration"`
 	SleepTime     ReadableDuration `json:"sleepTime"`
 	BackoffCapped bool             `json:"backoffCapped"`
 }
@@ -25,7 +28,7 @@ type LoopStatus struct {
 	NextCheck       ReadableDuration `json:"nextCheck"`
 	Interval        ReadableDuration `json:"interval"`
 	TimeSinceUpdate ReadableDuration `json:"timeSinceLastUpdate"`
-	TotalChecksRun  uint64           `json:"totalChecksRun"`
+	TotalChecksRun  uint32           `json:"totalChecksRun"`
 }
 
 // Report contains the full status report with statistics.

--- a/internal/status/report_test.go
+++ b/internal/status/report_test.go
@@ -18,9 +18,8 @@ func setupTestServer(t *testing.T, opts ...func(*StatServerConfig)) *StatHandler
 	status.SetRetention(1 * time.Hour)
 
 	config := &StatServerConfig{
-		Port:      8080,
-		Reports:   []time.Duration{time.Minute},
-		Retention: time.Hour,
+		Port:    8080,
+		Reports: []time.Duration{time.Minute},
 	}
 
 	for _, opt := range opts {
@@ -40,9 +39,8 @@ func TestStatHandlerInit(t *testing.T) {
 	status.SetRetention(1 * time.Hour)
 
 	config := &StatServerConfig{
-		Port:      8080,
-		Reports:   []time.Duration{time.Minute},
-		Retention: time.Hour,
+		Port:    8080,
+		Reports: []time.Duration{time.Minute},
 	}
 
 	server := &StatServer{

--- a/internal/status/report_test.go
+++ b/internal/status/report_test.go
@@ -86,7 +86,7 @@ func TestStatHandler_GenStatReport_WithChanges(t *testing.T) {
 	require.NotNil(t, report)
 	require.NotNil(t, report.Loop)
 	assert.True(t, report.Up)
-	assert.GreaterOrEqual(t, report.Loop.TotalChecksRun, uint64(3))
+	assert.GreaterOrEqual(t, report.Loop.TotalChecksRun, uint32(3))
 }
 
 func TestStatHandler_ServeHTTP(t *testing.T) {

--- a/internal/status/stat-server.go
+++ b/internal/status/stat-server.go
@@ -28,6 +28,7 @@ const (
 type StatServerConfig struct {
 	Port         int
 	Reports      []time.Duration
+	Buckets      BucketConfig
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 	IdleTimeout  time.Duration

--- a/internal/status/stat-server.go
+++ b/internal/status/stat-server.go
@@ -28,7 +28,6 @@ const (
 type StatServerConfig struct {
 	Port         int
 	Reports      []time.Duration
-	Retention    time.Duration
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 	IdleTimeout  time.Duration

--- a/internal/status/stat-server.go
+++ b/internal/status/stat-server.go
@@ -125,11 +125,3 @@ func serverHeader(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
-
-func defaultTimeout(d, def time.Duration) time.Duration {
-	if d == 0 {
-		return def
-	}
-
-	return d
-}

--- a/internal/status/stat-server_test.go
+++ b/internal/status/stat-server_test.go
@@ -46,9 +46,8 @@ func TestStartStatServer_NoPort(t *testing.T) {
 
 func TestStartStatServer_WithPort(t *testing.T) {
 	config := &StatServerConfig{
-		Port:      18765,
-		Reports:   []time.Duration{time.Minute},
-		Retention: time.Hour,
+		Port:    18765,
+		Reports: []time.Duration{time.Minute},
 	}
 
 	server := newStatServer(t, config)
@@ -60,7 +59,6 @@ func TestStatServer_Start_WithTimeouts(t *testing.T) {
 	config := &StatServerConfig{
 		Port:         18765,
 		Reports:      []time.Duration{time.Minute},
-		Retention:    time.Hour,
 		ReadTimeout:  2 * time.Second,
 		WriteTimeout: 2 * time.Second,
 		IdleTimeout:  2 * time.Second,
@@ -75,9 +73,8 @@ func TestStatServer_Start_WithTimeouts(t *testing.T) {
 
 func TestStatServer_Start_UsesDefaultTimeouts(t *testing.T) {
 	config := &StatServerConfig{
-		Port:      18765,
-		Reports:   []time.Duration{time.Minute},
-		Retention: time.Hour,
+		Port:    18765,
+		Reports: []time.Duration{time.Minute},
 	}
 
 	server := newStatServer(t, config)
@@ -98,9 +95,8 @@ func TestShutdown_NilServer(t *testing.T) {
 
 func TestShutdown_GracefulShutdown(t *testing.T) {
 	config := &StatServerConfig{
-		Port:      18765,
-		Reports:   []time.Duration{time.Minute},
-		Retention: time.Hour,
+		Port:    18765,
+		Reports: []time.Duration{time.Minute},
 	}
 
 	server := newStatServer(t, config)
@@ -109,9 +105,8 @@ func TestShutdown_GracefulShutdown(t *testing.T) {
 
 func TestStatServer_Route(t *testing.T) {
 	config := &StatServerConfig{
-		Port:      18765,
-		Reports:   []time.Duration{time.Minute},
-		Retention: time.Hour,
+		Port:    18765,
+		Reports: []time.Duration{time.Minute},
 	}
 
 	server := newStatServer(t, config)

--- a/internal/status/stat-server_test.go
+++ b/internal/status/stat-server_test.go
@@ -136,11 +136,6 @@ func TestStatServerConfigDefaults(t *testing.T) {
 	assert.Equal(t, "/stats.json", StatRoute)
 }
 
-func TestDefaultTimeout(t *testing.T) {
-	assert.Equal(t, 5*time.Second, defaultTimeout(0, 5*time.Second))
-	assert.Equal(t, 3*time.Second, defaultTimeout(3*time.Second, 5*time.Second))
-}
-
 func TestServerHeader_SetsHeaderOnSuccessfulRoute(t *testing.T) {
 	handler := serverHeader(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -94,6 +94,7 @@ type Status struct {
 	initialized        bool
 	mutex              sync.Mutex
 	stateChangeTracker *StateChangeTracker
+	rollingTracker     *RollingProbeTracker
 	downActionStatus   DownActionStatus
 	loopStatus         LoopStatus
 	lastSuccessAt      time.Time
@@ -126,6 +127,14 @@ func (s *Status) SetRetention(retention time.Duration) {
 		s.stateChangeTracker.retention = retention
 		s.stateChangeTracker.Prune(time.Now())
 	}
+}
+
+// SetRollingTracker attaches a probe stats tracker for per-period reporting.
+func (s *Status) SetRollingTracker(t *RollingProbeTracker) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.rollingTracker = t
 }
 
 // SetDownActionStatus stores a snapshot of the down action loop state.
@@ -234,6 +243,18 @@ func (s *Status) GenStatReport(periods []time.Duration) *Report {
 	rpt.Stats = s.stateChangeTracker.GenReports(s.Up, generated, periods)
 	rpt.Loop.TimeSinceUpdate = ReadableDuration(generated.Sub(s.stateChangeTracker.lastUpdated))
 	rpt.Loop.TotalChecksRun = s.stateChangeTracker.updateCount
+
+	if s.rollingTracker != nil {
+		for idx, period := range periods {
+			total, failed := s.rollingTracker.Stats(period, generated)
+			rpt.Stats[idx].TotalProbes = total
+
+			rpt.Stats[idx].FailedProbes = failed
+			if total > 0 {
+				rpt.Stats[idx].FailureRate = ReadablePercent(float64(failed) / float64(total))
+			}
+		}
+	}
 
 	return rpt
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -103,11 +103,7 @@ type Status struct {
 
 // NewStatus creates a new Status instance.
 func NewStatus() *Status {
-	var stateChangeTracker *StateChangeTracker
-
-	return &Status{
-		stateChangeTracker: stateChangeTracker,
-	}
+	return &Status{}
 }
 
 // SetRetention configures the retention period for state change history.

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -112,6 +112,9 @@ func NewStatus() *Status {
 
 // SetRetention configures the retention period for state change history.
 func (s *Status) SetRetention(retention time.Duration) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	if retention <= 0 {
 		s.stateChangeTracker = nil
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -17,7 +17,7 @@
 //	}
 //
 //	// Get current status:
-//	up := status.Get()
+//	up := status.Up
 //
 // Thread Safety:
 //

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -74,7 +74,7 @@ func TestSetDownActionStatus(t *testing.T) {
 
 	rpt := s.GenStatReport([]time.Duration{time.Minute})
 	require.NotNil(t, rpt.DownAction)
-	assert.Equal(t, uint64(7), rpt.DownAction.Iteration)
+	assert.Equal(t, uint32(7), rpt.DownAction.Iteration)
 	assert.Equal(t, ReadableDuration(30*time.Second), rpt.DownAction.SleepTime)
 	assert.True(t, rpt.DownAction.BackoffCapped)
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hugoh/upd/internal"
@@ -10,6 +11,7 @@ import (
 func main() {
 	err := internal.Cmd()
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/testdata/upd_test_good.toml
+++ b/testdata/upd_test_good.toml
@@ -24,5 +24,4 @@ repeat = "300s"
 
 [stats]
 port = 8080
-retention = "10080m"
 reports = ["10s", "15m", "60m", "1440m", "10080m"]

--- a/upd.toml
+++ b/upd.toml
@@ -1,4 +1,4 @@
-logLevel = "trace"
+logLevel = "debug"
 
 [checks]
 timeout = "2s"

--- a/upd.toml
+++ b/upd.toml
@@ -33,5 +33,4 @@ repeat = "3s"
 
 [stats]
 port = 8080
-retention = "10080m"
 reports = ["10s", "15m", "60m", "1440m", "10080m"]

--- a/upd_integration_test.go
+++ b/upd_integration_test.go
@@ -103,7 +103,6 @@ ordered = ["http://captive.apple.com/hotspot-detect.html"]
 [stats]
 port = %s
 reports = ["1m"]
-retention = "1h"
 `), port)
 	buildAndStartUpd(t, configContent)
 


### PR DESCRIPTION
- **feat(report): added probe target in logs**
- **feat(stats): additional failure / success details**
- **fix: potential race condition**
- **chore: removed dead code**
- **refactor: tests**
- **fix(stats): retention logic**
- **fix(cmd): process SIGHUP while worker is running**
- **fix(downaction): let StopExec run to completion**
- **fix(downaction): drop dead nil check after Process deref**
- **fix(logger): use slog.LevelVar for race-free level changes**
- **fix(main): print fatal error before exiting**
- **fix(check): bound entire DNS lookup by the check timeout**
- **refactor(check): set User-Agent at request build, drain body**
- **fix(check): report https scheme for HTTPS probes**
- **fix(config): fail config load on invalid checks**
- **fix(status): finer probe-stat buckets to bound window skew**
- **refactor(config): name nested config structs, drop reflect**
- **refactor(cmd): reuse GetStatServerConfig for report periods**
- **refactor(logic): replace Delays map[bool] with a struct**
- **refactor(check): replace iterator types with iter.Seq**
- **refactor: simplify timers and small idioms**
- **docs: TOML examples in config doc, fix stale status.Get() ref**
- **style: satisfy golangci-lint**
- **perf(status): 8-byte probe buckets, cap ring size**
- **feat(status): per-period probe-stat rings with bucket tuning**
