### PR TITLE
feat(status): surface partial-period stats instead of suppressing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,29 +100,46 @@ The sample configuration above will provide data looking like this:
   "isUp": true,
   "reports": [
     {
-      "period": "1m",
+      "period": "10s",
       "availability": "100.00 %",
-      "downTime": "0s"
+      "downTime": "0s",
+      "totalProbes": 1,
+      "failedProbes": 0,
+      "failureRate": "0.00 %"
     },
     {
       "period": "15m",
       "availability": "100.00 %",
-      "downTime": "0s"
+      "downTime": "0s",
+      "totalProbes": 15,
+      "failedProbes": 0,
+      "failureRate": "0.00 %"
     },
     {
       "period": "1h",
       "availability": "100.00 %",
-      "downTime": "0s"
+      "downTime": "0s",
+      "totalProbes": 60,
+      "failedProbes": 0,
+      "failureRate": "0.00 %"
     },
     {
       "period": "24h",
-      "availability": "Not computed",
-      "downTime": "0s"
+      "coverage": "12h33m23s",
+      "availability": "100.00 %",
+      "downTime": "0s",
+      "totalProbes": 753,
+      "failedProbes": 0,
+      "failureRate": "0.00 %"
     },
     {
       "period": "168h",
-      "availability": "Not computed",
-      "downTime": "0s"
+      "coverage": "12h33m23s",
+      "availability": "100.00 %",
+      "downTime": "0s",
+      "totalProbes": 753,
+      "failedProbes": 0,
+      "failureRate": "0.00 %"
     }
   ],
   "loop": {
@@ -133,7 +150,7 @@ The sample configuration above will provide data looking like this:
     "totalChecksRun": 753
   },
   "updUptime": "12h33m23s",
-  "updVersion": "4.2.0",
+  "updVersion": "4.4.0",
   "generatedAt": "2026-06-09T07:37:00.70887063-05:00"
 }
 ```

--- a/internal/status/changetracker.go
+++ b/internal/status/changetracker.go
@@ -1,8 +1,21 @@
 package status
 
 import (
+	"errors"
+	"fmt"
 	"time"
 )
+
+// ErrPeriodExceedsRetention is returned when the requested period is longer
+// than the configured retention window.
+var ErrPeriodExceedsRetention = errors.New("period exceeds retention")
+
+// UptimeResult holds the result of an uptime calculation.
+type UptimeResult struct {
+	Availability float64
+	Downtime     time.Duration
+	Coverage     time.Duration
+}
 
 // StateChange represents a single state transition in the tracker.
 type StateChange struct {
@@ -69,15 +82,27 @@ func (tracker *StateChangeTracker) Prune(currentTime time.Time) {
 	}
 }
 
-// CalculateUptime computes availability percentage and downtime for a given period.
+// CalculateUptime computes availability, downtime, and coverage for a given
+// period. Coverage may be less than last when the tracker started recently.
+// Returns an error if last exceeds the configured retention (data was pruned
+// and cannot be recovered).
 func (tracker *StateChangeTracker) CalculateUptime(currentState bool,
 	last time.Duration, end time.Time,
-) (float64, time.Duration) {
-	if last > tracker.retention || end.Sub(tracker.started) < last {
-		return -1, 0
+) (UptimeResult, error) {
+	if last > tracker.retention {
+		return UptimeResult{}, fmt.Errorf(
+			"%w: period %v exceeds retention %v",
+			ErrPeriodExceedsRetention,
+			last,
+			tracker.retention,
+		)
 	}
 
-	return tracker.uptimeCalculation(currentState, last, end)
+	coverage := min(end.Sub(tracker.started), last)
+	result := tracker.uptimeCalculation(currentState, coverage, end)
+	result.Coverage = coverage
+
+	return result, nil
 }
 
 // RecordsCount returns the number of state changes in the tracker.
@@ -109,13 +134,28 @@ func (tracker *StateChangeTracker) GenReports(currentState bool, end time.Time,
 	for idx := range periods {
 		period := periods[idx]
 
-		availability, downtime := tracker.CalculateUptime(currentState, period, end)
+		result, err := tracker.CalculateUptime(currentState, period, end)
+		if err != nil {
+			reports[idx] = ReportByPeriod{
+				Period:       ReadableDuration(period),
+				Availability: ReadablePercent(-1),
+			}
 
-		reports[idx] = ReportByPeriod{
-			Period:       ReadableDuration(period),
-			Availability: ReadablePercent(availability),
-			Downtime:     ReadableDuration(downtime),
+			continue
 		}
+
+		rpt := ReportByPeriod{
+			Period:       ReadableDuration(period),
+			Availability: ReadablePercent(result.Availability),
+			Downtime:     ReadableDuration(result.Downtime),
+		}
+
+		if result.Coverage < period {
+			c := ReadableDuration(result.Coverage)
+			rpt.Coverage = &c
+		}
+
+		reports[idx] = rpt
 	}
 
 	return reports
@@ -123,14 +163,14 @@ func (tracker *StateChangeTracker) GenReports(currentState bool, end time.Time,
 
 func (tracker *StateChangeTracker) uptimeCalculation(currentState bool,
 	last time.Duration, end time.Time,
-) (float64, time.Duration) {
+) UptimeResult {
 	if tracker.tail == nil {
 		// No records other than the current status
 		if currentState {
-			return 1.0, 0
+			return UptimeResult{Availability: 1.0}
 		}
 
-		return 0.0, last
+		return UptimeResult{Downtime: last}
 	}
 
 	uptime := time.Duration(0)
@@ -171,5 +211,8 @@ func (tracker *StateChangeTracker) uptimeCalculation(currentState bool,
 		}
 	}
 
-	return (float64(uptime) / float64(last)), last - uptime
+	return UptimeResult{
+		Availability: float64(uptime) / float64(last),
+		Downtime:     last - uptime,
+	}
 }

--- a/internal/status/changetracker_test.go
+++ b/internal/status/changetracker_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -125,78 +126,78 @@ func (suite *TestSuiteStats) TestCalc_EmptyTracker() {
 	t := suite.T()
 	empty := GetTracker()
 
-	actual, downtime := empty.uptimeCalculation(true, 1*time.Minute, suite.Now)
-	assert.InEpsilon(t, 1.0, actual, 0.01)
-	assert.Equal(t, time.Duration(0), downtime)
+	result := empty.uptimeCalculation(true, 1*time.Minute, suite.Now)
+	assert.InEpsilon(t, 1.0, result.Availability, 0.01)
+	assert.Equal(t, time.Duration(0), result.Downtime)
 
-	actual, downtime = empty.uptimeCalculation(false, 1*time.Minute, suite.Now)
-	assert.InDelta(t, 0.0, actual, 0.0001)
-	assert.Equal(t, 1*time.Minute, downtime)
+	result = empty.uptimeCalculation(false, 1*time.Minute, suite.Now)
+	assert.InDelta(t, 0.0, result.Availability, 0.0001)
+	assert.Equal(t, 1*time.Minute, result.Downtime)
 }
 
 func (suite *TestSuiteStats) TestCalc_TrackerWithinOneMinute() {
 	t := suite.T()
 	tracker := suite.Tracker
 
-	actual, downtime := tracker.uptimeCalculation(true, 1*time.Minute, suite.Now)
-	assert.InEpsilon(t, 1.0, actual, 0.01)
-	assert.Equal(t, time.Duration(0), downtime)
+	result := tracker.uptimeCalculation(true, 1*time.Minute, suite.Now)
+	assert.InEpsilon(t, 1.0, result.Availability, 0.01)
+	assert.Equal(t, time.Duration(0), result.Downtime)
 
-	actual, downtime = tracker.uptimeCalculation(false, 1*time.Minute, suite.Now)
-	assert.InEpsilon(t, 1.0, actual, 0.01)
-	assert.Equal(t, time.Duration(0), downtime)
+	result = tracker.uptimeCalculation(false, 1*time.Minute, suite.Now)
+	assert.InEpsilon(t, 1.0, result.Availability, 0.01)
+	assert.Equal(t, time.Duration(0), result.Downtime)
 }
 
 func (suite *TestSuiteStats) TestCalc_TrackerWithinFourteenMinutes() {
 	t := suite.T()
 	tracker := suite.Tracker
 
-	actual, downtime := tracker.uptimeCalculation(true, 14*time.Minute, suite.Now)
-	assert.InEpsilon(t, 1.0, actual, 0.01)
-	assert.Equal(t, time.Duration(0), downtime)
+	result := tracker.uptimeCalculation(true, 14*time.Minute, suite.Now)
+	assert.InEpsilon(t, 1.0, result.Availability, 0.01)
+	assert.Equal(t, time.Duration(0), result.Downtime)
 
-	actual, downtime = tracker.uptimeCalculation(false, 14*time.Minute, suite.Now)
-	assert.InEpsilon(t, 1.0, actual, 0.01)
-	assert.Equal(t, time.Duration(0), downtime)
+	result = tracker.uptimeCalculation(false, 14*time.Minute, suite.Now)
+	assert.InEpsilon(t, 1.0, result.Availability, 0.01)
+	assert.Equal(t, time.Duration(0), result.Downtime)
 }
 
 func (suite *TestSuiteStats) TestCalc_TrackerWithinSixteenMinutes() {
 	t := suite.T()
 	tracker := suite.Tracker
 
-	actual, downtime := tracker.uptimeCalculation(true, 16*time.Minute, suite.Now)
-	assert.InEpsilon(t, 15.0/16.0, actual, 0.01)
-	assert.Equal(t, 1*time.Minute, downtime)
+	result := tracker.uptimeCalculation(true, 16*time.Minute, suite.Now)
+	assert.InEpsilon(t, 15.0/16.0, result.Availability, 0.01)
+	assert.Equal(t, 1*time.Minute, result.Downtime)
 
-	actual, downtime = tracker.uptimeCalculation(false, 16*time.Minute, suite.Now)
-	assert.InEpsilon(t, 15.0/16.0, actual, 0.01)
-	assert.Equal(t, 1*time.Minute, downtime)
+	result = tracker.uptimeCalculation(false, 16*time.Minute, suite.Now)
+	assert.InEpsilon(t, 15.0/16.0, result.Availability, 0.01)
+	assert.Equal(t, 1*time.Minute, result.Downtime)
 }
 
 func (suite *TestSuiteStats) TestCalc_TrackerWithinThirtyMinutes() {
 	t := suite.T()
 	tracker := suite.Tracker
 
-	actual, downtime := tracker.uptimeCalculation(true, 30*time.Minute, suite.Now)
-	assert.InEpsilon(t, 0.5, actual, 0.01)
-	assert.Equal(t, 15*time.Minute, downtime)
+	result := tracker.uptimeCalculation(true, 30*time.Minute, suite.Now)
+	assert.InEpsilon(t, 0.5, result.Availability, 0.01)
+	assert.Equal(t, 15*time.Minute, result.Downtime)
 
-	actual, downtime = tracker.uptimeCalculation(false, 30*time.Minute, suite.Now)
-	assert.InEpsilon(t, 0.5, actual, 0.01)
-	assert.Equal(t, 15*time.Minute, downtime)
+	result = tracker.uptimeCalculation(false, 30*time.Minute, suite.Now)
+	assert.InEpsilon(t, 0.5, result.Availability, 0.01)
+	assert.Equal(t, 15*time.Minute, result.Downtime)
 }
 
 func (suite *TestSuiteStats) TestCalc_TrackerWithinTwentyFourHours() {
 	t := suite.T()
 	tracker := suite.Tracker
 
-	actual, downtime := tracker.uptimeCalculation(true, 24*time.Hour, suite.Now)
-	assert.InEpsilon(t, 0.75/24, actual, 0.01)
-	assert.Equal(t, 23*time.Hour+15*time.Minute, downtime)
+	result := tracker.uptimeCalculation(true, 24*time.Hour, suite.Now)
+	assert.InEpsilon(t, 0.75/24, result.Availability, 0.01)
+	assert.Equal(t, 23*time.Hour+15*time.Minute, result.Downtime)
 
-	actual, downtime = tracker.uptimeCalculation(false, 24*time.Hour, suite.Now)
-	assert.InEpsilon(t, 0.75/24, actual, 0.01)
-	assert.Equal(t, 23*time.Hour+15*time.Minute, downtime)
+	result = tracker.uptimeCalculation(false, 24*time.Hour, suite.Now)
+	assert.InEpsilon(t, 0.75/24, result.Availability, 0.01)
+	assert.Equal(t, 23*time.Hour+15*time.Minute, result.Downtime)
 }
 
 func (suite *TestSuiteStats) TestCalc_EmptyWithRecordChange() {
@@ -204,43 +205,46 @@ func (suite *TestSuiteStats) TestCalc_EmptyWithRecordChange() {
 	empty := GetTracker()
 	empty.RecordChange(suite.Now.Add(-2*time.Hour), false)
 
-	actual, downtime := empty.uptimeCalculation(true, 1*time.Hour, suite.Now)
-	assert.InDelta(t, 0.0, actual, 0.0001)
-	assert.Equal(t, 1*time.Hour, downtime)
+	result := empty.uptimeCalculation(true, 1*time.Hour, suite.Now)
+	assert.InDelta(t, 0.0, result.Availability, 0.0001)
+	assert.Equal(t, 1*time.Hour, result.Downtime)
 
-	actual, downtime = empty.uptimeCalculation(false, 1*time.Hour, suite.Now)
-	assert.InDelta(t, 0.0, actual, 0.0001)
-	assert.Equal(t, 1*time.Hour, downtime)
+	result = empty.uptimeCalculation(false, 1*time.Hour, suite.Now)
+	assert.InDelta(t, 0.0, result.Availability, 0.0001)
+	assert.Equal(t, 1*time.Hour, result.Downtime)
 
-	actual, downtime = empty.uptimeCalculation(true, 2*time.Hour, suite.Now)
-	assert.InDelta(t, 0.0, actual, 0.0001)
-	assert.Equal(t, 2*time.Hour, downtime)
+	result = empty.uptimeCalculation(true, 2*time.Hour, suite.Now)
+	assert.InDelta(t, 0.0, result.Availability, 0.0001)
+	assert.Equal(t, 2*time.Hour, result.Downtime)
 
-	actual, downtime = empty.uptimeCalculation(false, 2*time.Hour, suite.Now)
-	assert.InDelta(t, 0.0, actual, 0.0001)
-	assert.Equal(t, 2*time.Hour, downtime)
+	result = empty.uptimeCalculation(false, 2*time.Hour, suite.Now)
+	assert.InDelta(t, 0.0, result.Availability, 0.0001)
+	assert.Equal(t, 2*time.Hour, result.Downtime)
 
-	actual, downtime = empty.uptimeCalculation(true, 24*time.Hour, suite.Now)
-	assert.InEpsilon(t, 22.0/24, actual, 0.01)
-	assert.Equal(t, 2*time.Hour, downtime)
+	result = empty.uptimeCalculation(true, 24*time.Hour, suite.Now)
+	assert.InEpsilon(t, 22.0/24, result.Availability, 0.01)
+	assert.Equal(t, 2*time.Hour, result.Downtime)
 
-	actual, downtime = empty.uptimeCalculation(false, 24*time.Hour, suite.Now)
-	assert.InEpsilon(t, 22.0/24, actual, 0.01)
-	assert.Equal(t, 2*time.Hour, downtime)
+	result = empty.uptimeCalculation(false, 24*time.Hour, suite.Now)
+	assert.InEpsilon(t, 22.0/24, result.Availability, 0.01)
+	assert.Equal(t, 2*time.Hour, result.Downtime)
 
 	empty.started = suite.Now.Add(-1 * time.Minute)
-	v, w := empty.CalculateUptime(false, 1*time.Hour, suite.Now)
-	assert.InDelta(t, -1.0, v, 0.0001)
-	assert.Equal(t, time.Duration(0), w)
+	result, err := empty.CalculateUptime(false, 1*time.Hour, suite.Now)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.0, result.Availability, 0.0001)
+	assert.Equal(t, 1*time.Minute, result.Downtime)
+	assert.Equal(t, 1*time.Minute, result.Coverage)
 }
 
 func (suite *TestSuiteStats) TestCalcError() {
 	empty := GetTracker()
 
-	v, d := empty.CalculateUptime(true, 72*time.Hour, suite.Now)
-	suite.InDelta(-1.0, v, 0.0001)
-	suite.Equal(time.Duration(0), d)
-	v, d = empty.CalculateUptime(true, 24*time.Hour, suite.Now)
-	suite.InDelta(1.0, v, 0.0001)
-	suite.Equal(time.Duration(0), d)
+	_, err := empty.CalculateUptime(true, 72*time.Hour, suite.Now)
+	suite.Require().Error(err)
+
+	result, err := empty.CalculateUptime(true, 24*time.Hour, suite.Now)
+	suite.Require().NoError(err)
+	suite.InDelta(1.0, result.Availability, 0.0001)
+	suite.Equal(time.Duration(0), result.Downtime)
 }

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -6,6 +6,13 @@ import (
 	"time"
 )
 
+// ProbeStats holds the result of a probe stats query.
+type ProbeStats struct {
+	Total    int
+	Failed   int
+	Coverage time.Duration
+}
+
 // probeBucket counts probe results within one bucket interval. Bucket start
 // times are not stored: they are derived from the ring's lastTime and the
 // bucket's distance from the newest bucket, keeping rings at 8 bytes per
@@ -105,20 +112,23 @@ func (t *RollingProbeTracker) Record(failed bool) {
 	}
 }
 
-// Stats returns (total, failed) probe results within the given report period
-// before now. The period must be one of the configured report periods;
-// unknown periods report no data.
-func (t *RollingProbeTracker) Stats(period time.Duration, now time.Time) (int, int) {
+// Stats returns probe results within the given report period before now.
+// Coverage may be less than period at startup. The period must be one of the
+// configured report periods; unknown periods return a zero ProbeStats.
+func (t *RollingProbeTracker) Stats(period time.Duration, now time.Time) ProbeStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	for _, ring := range t.rings {
 		if ring.period == period {
-			return ring.statsSince(now.Add(-period))
+			result := ring.statsSince(now.Add(-period))
+			result.Coverage = min(time.Duration(ring.count)*ring.interval, period)
+
+			return result
 		}
 	}
 
-	return 0, 0
+	return ProbeStats{}
 }
 
 // newestIdx returns the ring index of the newest bucket. Must be called with
@@ -178,9 +188,9 @@ func (r *probeRing) advanceTo(bucketTime time.Time) {
 
 // statsSince sums the buckets that start at or after cutoff. Must be called
 // with the tracker lock held.
-func (r *probeRing) statsSince(cutoff time.Time) (int, int) {
+func (r *probeRing) statsSince(cutoff time.Time) ProbeStats {
 	if r.count == 0 {
-		return 0, 0
+		return ProbeStats{}
 	}
 
 	oldest := r.lastTime.Add(-time.Duration(r.count-1) * r.interval)
@@ -191,13 +201,13 @@ func (r *probeRing) statsSince(cutoff time.Time) (int, int) {
 		skip = min(int((diff+r.interval-1)/r.interval), r.count)
 	}
 
-	var total, failed int
+	var result ProbeStats
 
 	for i := skip; i < r.count; i++ {
 		bucket := r.buckets[(r.head+i)%len(r.buckets)]
-		total += int(bucket.total)
-		failed += int(bucket.failed)
+		result.Total += int(bucket.total)
+		result.Failed += int(bucket.failed)
 	}
 
-	return total, failed
+	return result
 }

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -55,9 +55,9 @@ func TestRollingProbeTracker_Record(t *testing.T) {
 		tracker.Record(false)
 	}
 
-	total, failed := tracker.Stats(time.Hour, now.Add(time.Minute))
-	assert.Equal(t, 3, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.Stats(time.Hour, now.Add(time.Minute))
+	assert.Equal(t, 3, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_RecordFailed(t *testing.T) {
@@ -67,17 +67,17 @@ func TestRollingProbeTracker_RecordFailed(t *testing.T) {
 	tracker.Record(true)
 	tracker.Record(false)
 
-	total, failed := tracker.Stats(time.Hour, time.Now())
-	assert.Equal(t, 3, total)
-	assert.Equal(t, 1, failed)
+	ps := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 3, ps.Total)
+	assert.Equal(t, 1, ps.Failed)
 }
 
 func TestRollingProbeTracker_Empty(t *testing.T) {
 	tracker := newSingleRingTracker(time.Hour, time.Minute)
 
-	total, failed := tracker.Stats(time.Hour, time.Now())
-	assert.Equal(t, 0, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 0, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_UnknownPeriod(t *testing.T) {
@@ -85,9 +85,9 @@ func TestRollingProbeTracker_UnknownPeriod(t *testing.T) {
 
 	tracker.Record(false)
 
-	total, failed := tracker.Stats(2*time.Hour, time.Now())
-	assert.Equal(t, 0, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.Stats(2*time.Hour, time.Now())
+	assert.Equal(t, 0, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_NoPeriods(t *testing.T) {
@@ -95,9 +95,9 @@ func TestRollingProbeTracker_NoPeriods(t *testing.T) {
 
 	tracker.Record(false)
 
-	total, failed := tracker.Stats(time.Hour, time.Now())
-	assert.Equal(t, 0, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 0, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_OutsideWindow(t *testing.T) {
@@ -108,9 +108,9 @@ func TestRollingProbeTracker_OutsideWindow(t *testing.T) {
 	tracker.rings[0].recordAt(now)
 	tracker.mu.Unlock()
 
-	total, failed := tracker.Stats(time.Hour, now.Add(2*time.Hour))
-	assert.Equal(t, 0, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.Stats(time.Hour, now.Add(2*time.Hour))
+	assert.Equal(t, 0, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_BucketAdvancement(t *testing.T) {
@@ -122,9 +122,9 @@ func TestRollingProbeTracker_BucketAdvancement(t *testing.T) {
 	tracker.rings[0].recordAt(now.Add(2 * time.Minute)) // bucket 3 (bucket 2 is empty gap)
 	tracker.mu.Unlock()
 
-	total, failed := tracker.Stats(time.Hour, now.Add(3*time.Minute))
-	assert.Equal(t, 2, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.Stats(time.Hour, now.Add(3*time.Minute))
+	assert.Equal(t, 2, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_WrapAround(t *testing.T) {
@@ -141,14 +141,14 @@ func TestRollingProbeTracker_WrapAround(t *testing.T) {
 
 	// After 20 minutes of 1-min buckets with 6 buckets, only 6 remain even
 	// for a cutoff far in the past.
-	total, _ := tracker.rings[0].statsSince(now.Add(-time.Hour))
+	ps := tracker.rings[0].statsSince(now.Add(-time.Hour))
 	tracker.mu.Unlock()
 
-	assert.Equal(t, 6, total)
+	assert.Equal(t, 6, ps.Total)
 
 	// The 5m report window itself covers the 5 newest buckets.
-	total, _ = tracker.Stats(5*time.Minute, now)
-	assert.Equal(t, 5, total)
+	ps = tracker.Stats(5*time.Minute, now)
+	assert.Equal(t, 5, ps.Total)
 }
 
 func TestRollingProbeTracker_LongGapResets(t *testing.T) {
@@ -162,9 +162,9 @@ func TestRollingProbeTracker_LongGapResets(t *testing.T) {
 	tracker.rings[0].recordAt(now.Add(24 * time.Hour))
 	tracker.mu.Unlock()
 
-	total, failed := tracker.Stats(5*time.Minute, now.Add(24*time.Hour))
-	assert.Equal(t, 1, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.Stats(5*time.Minute, now.Add(24*time.Hour))
+	assert.Equal(t, 1, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_PerPeriodGranularity(t *testing.T) {
@@ -184,12 +184,12 @@ func TestRollingProbeTracker_PerPeriodGranularity(t *testing.T) {
 	tracker.mu.Unlock()
 
 	// The 1m window only sees the most recent probe.
-	total, _ := tracker.Stats(time.Minute, base.Add(2*time.Minute))
-	assert.Equal(t, 1, total)
+	ps := tracker.Stats(time.Minute, base.Add(2*time.Minute))
+	assert.Equal(t, 1, ps.Total)
 
 	// The 1h window sees both.
-	total, _ = tracker.Stats(time.Hour, base.Add(2*time.Minute))
-	assert.Equal(t, 2, total)
+	ps = tracker.Stats(time.Hour, base.Add(2*time.Minute))
+	assert.Equal(t, 2, ps.Total)
 }
 
 func TestRollingProbeTracker_ConcurrentAccess(t *testing.T) {
@@ -207,9 +207,9 @@ func TestRollingProbeTracker_ConcurrentAccess(t *testing.T) {
 
 	wg.Wait()
 
-	total, failed := tracker.Stats(time.Hour, time.Now())
-	assert.Equal(t, 1000, total)
-	assert.Equal(t, 1000, failed)
+	ps := tracker.Stats(time.Hour, time.Now())
+	assert.Equal(t, 1000, ps.Total)
+	assert.Equal(t, 1000, ps.Failed)
 }
 
 func TestRollingProbeTracker_AlignedWindow(t *testing.T) {
@@ -225,14 +225,14 @@ func TestRollingProbeTracker_AlignedWindow(t *testing.T) {
 	tracker.mu.Unlock()
 
 	// 1h window from 12:55:05 → cutoff = 12:00:05 (later bucket boundary)
-	total, failed := tracker.rings[0].statsSince(base.Add(5 * time.Second))
-	assert.Equal(t, 1, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.rings[0].statsSince(base.Add(5 * time.Second))
+	assert.Equal(t, 1, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 
 	// Cutoff = 12:00:00 (first bucket boundary): both included
-	total, failed = tracker.rings[0].statsSince(base)
-	assert.Equal(t, 2, total)
-	assert.Equal(t, 0, failed)
+	ps = tracker.rings[0].statsSince(base)
+	assert.Equal(t, 2, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }
 
 func TestRollingProbeTracker_NonAlignedWindow(t *testing.T) {
@@ -250,12 +250,12 @@ func TestRollingProbeTracker_NonAlignedWindow(t *testing.T) {
 	// Cutoff = 12:00:03 (middle of first bucket):
 	// Bucket [12:00:00, 12:00:05): starts before cutoff → excluded
 	// Bucket [12:00:05, 12:00:10): starts at or after cutoff → included
-	total, failed := tracker.rings[0].statsSince(base.Add(3 * time.Second))
-	assert.Equal(t, 1, total)
-	assert.Equal(t, 0, failed)
+	ps := tracker.rings[0].statsSince(base.Add(3 * time.Second))
+	assert.Equal(t, 1, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 
 	// Cutoff = 11:59:59: both buckets included
-	total, failed = tracker.rings[0].statsSince(base.Add(-time.Second))
-	assert.Equal(t, 2, total)
-	assert.Equal(t, 0, failed)
+	ps = tracker.rings[0].statsSince(base.Add(-time.Second))
+	assert.Equal(t, 2, ps.Total)
+	assert.Equal(t, 0, ps.Failed)
 }

--- a/internal/status/report.go
+++ b/internal/status/report.go
@@ -7,12 +7,13 @@ const JSONIndentSpaces = "  "
 
 // ReportByPeriod contains uptime statistics for a specific time period.
 type ReportByPeriod struct {
-	Period       ReadableDuration `json:"period"`
-	Availability ReadablePercent  `json:"availability"`
-	Downtime     ReadableDuration `json:"downTime"`
-	TotalProbes  int              `json:"totalProbes"`
-	FailedProbes int              `json:"failedProbes"`
-	FailureRate  ReadablePercent  `json:"failureRate"`
+	Period       ReadableDuration  `json:"period"`
+	Coverage     *ReadableDuration `json:"coverage,omitempty"`
+	Availability ReadablePercent   `json:"availability"`
+	Downtime     ReadableDuration  `json:"downTime"`
+	TotalProbes  int               `json:"totalProbes"`
+	FailedProbes int               `json:"failedProbes"`
+	FailureRate  ReadablePercent   `json:"failureRate"`
 }
 
 // DownActionStatus contains the current state of the down action loop.

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -245,12 +245,12 @@ func (s *Status) GenStatReport(periods []time.Duration) *Report {
 
 	if s.rollingTracker != nil {
 		for idx, period := range periods {
-			total, failed := s.rollingTracker.Stats(period, generated)
-			rpt.Stats[idx].TotalProbes = total
+			ps := s.rollingTracker.Stats(period, generated)
+			rpt.Stats[idx].TotalProbes = ps.Total
 
-			rpt.Stats[idx].FailedProbes = failed
-			if total > 0 {
-				rpt.Stats[idx].FailureRate = ReadablePercent(float64(failed) / float64(total))
+			rpt.Stats[idx].FailedProbes = ps.Failed
+			if ps.Total > 0 {
+				rpt.Stats[idx].FailureRate = ReadablePercent(float64(ps.Failed) / float64(ps.Total))
 			}
 		}
 	}


### PR DESCRIPTION
CalculateUptime previously returned -1/"Not computed" for any period
not yet fully elapsed, leaving the stats endpoint dark for hours after
startup on long report windows.

Now returns real data with a Coverage field reflecting the actual
window; Coverage is omitted from JSON when it equals the full period.
Error (ErrPeriodExceedsRetention) replaces the -1 sentinel for the
only remaining uncomputable case: period > retention.

Also replaces positional multi-returns with named structs
(UptimeResult, ProbeStats) across both public and private methods.
