### PR TITLE
fixes

### DIFF
--- a/internal/status/changetracker.go
+++ b/internal/status/changetracker.go
@@ -98,7 +98,12 @@ func (tracker *StateChangeTracker) CalculateUptime(currentState bool,
 		)
 	}
 
-	coverage := min(end.Sub(tracker.started), last)
+	coverage := max(min(end.Sub(tracker.started), last), 0)
+	if coverage == 0 {
+		// Tracker started at or after the query time (e.g. backward clock step).
+		return UptimeResult{}, nil
+	}
+
 	result := tracker.uptimeCalculation(currentState, coverage, end)
 	result.Coverage = coverage
 

--- a/internal/status/changetracker.go
+++ b/internal/status/changetracker.go
@@ -139,6 +139,7 @@ func (tracker *StateChangeTracker) GenReports(currentState bool, end time.Time,
 			reports[idx] = ReportByPeriod{
 				Period:       ReadableDuration(period),
 				Availability: ReadablePercent(-1),
+				Downtime:     NotComputedDuration,
 			}
 
 			continue

--- a/internal/status/changetracker_test.go
+++ b/internal/status/changetracker_test.go
@@ -248,3 +248,17 @@ func (suite *TestSuiteStats) TestCalcError() {
 	suite.InDelta(1.0, result.Availability, 0.0001)
 	suite.Equal(time.Duration(0), result.Downtime)
 }
+
+func TestGenReports_ErrorPath_NotComputedDowntime(t *testing.T) {
+	// A tracker with 1h retention asked for a 24h period returns "Not computed"
+	// for both Availability and Downtime rather than a misleading "0s".
+	tracker := &StateChangeTracker{
+		retention: time.Hour,
+		started:   time.Now().Add(-time.Hour),
+	}
+
+	reports := tracker.GenReports(true, time.Now(), []time.Duration{24 * time.Hour})
+	require.Len(t, reports, 1)
+	assert.Equal(t, ReadablePercent(-1), reports[0].Availability)
+	assert.Equal(t, NotComputedDuration, reports[0].Downtime)
+}

--- a/internal/status/changetracker_test.go
+++ b/internal/status/changetracker_test.go
@@ -249,6 +249,23 @@ func (suite *TestSuiteStats) TestCalcError() {
 	suite.Equal(time.Duration(0), result.Downtime)
 }
 
+func TestCalculateUptime_ClockSkew_ReturnsSafeZero(t *testing.T) {
+	// Simulate end < started (backward clock step). Should not panic or produce
+	// NaN/negative values; should return a zero UptimeResult with no error.
+	tracker := &StateChangeTracker{
+		retention: time.Hour,
+		started:   time.Now(),
+	}
+	tracker.RecordChange(time.Now().Add(-time.Minute), false)
+
+	// end is one second in the past relative to started.
+	result, err := tracker.CalculateUptime(false, time.Minute, time.Now().Add(-time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), result.Availability)
+	assert.Equal(t, time.Duration(0), result.Downtime)
+	assert.Equal(t, time.Duration(0), result.Coverage)
+}
+
 func TestGenReports_ErrorPath_NotComputedDowntime(t *testing.T) {
 	// A tracker with 1h retention asked for a 24h period returns "Not computed"
 	// for both Availability and Downtime rather than a misleading "0s".

--- a/internal/status/changetracker_test.go
+++ b/internal/status/changetracker_test.go
@@ -261,7 +261,7 @@ func TestCalculateUptime_ClockSkew_ReturnsSafeZero(t *testing.T) {
 	// end is one second in the past relative to started.
 	result, err := tracker.CalculateUptime(false, time.Minute, time.Now().Add(-time.Second))
 	require.NoError(t, err)
-	assert.Equal(t, float64(0), result.Availability)
+	assert.InDelta(t, 0.0, result.Availability, 0.0001)
 	assert.Equal(t, time.Duration(0), result.Downtime)
 	assert.Equal(t, time.Duration(0), result.Coverage)
 }
@@ -276,6 +276,6 @@ func TestGenReports_ErrorPath_NotComputedDowntime(t *testing.T) {
 
 	reports := tracker.GenReports(true, time.Now(), []time.Duration{24 * time.Hour})
 	require.Len(t, reports, 1)
-	assert.Equal(t, ReadablePercent(-1), reports[0].Availability)
+	assert.InDelta(t, float64(-1), float64(reports[0].Availability), 0.0001)
 	assert.Equal(t, NotComputedDuration, reports[0].Downtime)
 }

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"cmp"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -112,8 +113,8 @@ func (t *RollingProbeTracker) Record(failed bool) {
 }
 
 // Stats returns probe results within the given report period before now.
-// Coverage may be less than period at startup. The period must be one of the
-// configured report periods; unknown periods return a zero ProbeStats.
+// Panics if period is not one of the configured report periods — use StatsAll
+// for bulk reads that avoid this constraint.
 func (t *RollingProbeTracker) Stats(period time.Duration, now time.Time) ProbeStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -124,7 +125,7 @@ func (t *RollingProbeTracker) Stats(period time.Duration, now time.Time) ProbeSt
 		}
 	}
 
-	return ProbeStats{}
+	panic(fmt.Sprintf("RollingProbeTracker.Stats: no ring for period %v", period))
 }
 
 // StatsAll returns probe results for every configured ring in construction

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -188,14 +188,27 @@ func (r *probeRing) advanceTo(bucketTime time.Time) {
 		return
 	}
 
-	for range steps {
-		if r.count == maxBuckets {
-			r.buckets[r.head] = probeBucket{}
-			r.head = (r.head + 1) % maxBuckets
+	if r.count == maxBuckets {
+		// Ring is full: batch-zero the evicted slots and rotate head in one
+		// step instead of looping. The evicted range [head, head+steps) wraps
+		// around, so handle the two contiguous halves separately.
+		newHead := (r.head + steps) % maxBuckets
+		if newHead > r.head {
+			clear(r.buckets[r.head:newHead])
 		} else {
-			r.buckets[(r.head+r.count)%maxBuckets] = probeBucket{}
-			r.count++
+			clear(r.buckets[r.head:])
+			if newHead > 0 {
+				clear(r.buckets[:newHead])
+			}
 		}
+		r.head = newHead
+
+		return
+	}
+
+	for range steps {
+		r.buckets[(r.head+r.count)%maxBuckets] = probeBucket{}
+		r.count++
 	}
 }
 

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -8,9 +8,8 @@ import (
 
 // ProbeStats holds the result of a probe stats query.
 type ProbeStats struct {
-	Total    int
-	Failed   int
-	Coverage time.Duration
+	Total  int
+	Failed int
 }
 
 // probeBucket counts probe results within one bucket interval. Bucket start
@@ -121,10 +120,7 @@ func (t *RollingProbeTracker) Stats(period time.Duration, now time.Time) ProbeSt
 
 	for _, ring := range t.rings {
 		if ring.period == period {
-			result := ring.statsSince(now.Add(-period))
-			result.Coverage = min(time.Duration(ring.count)*ring.interval, period)
-
-			return result
+			return ring.statsSince(now.Add(-period))
 		}
 	}
 

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -197,10 +197,12 @@ func (r *probeRing) advanceTo(bucketTime time.Time) {
 			clear(r.buckets[r.head:newHead])
 		} else {
 			clear(r.buckets[r.head:])
+
 			if newHead > 0 {
 				clear(r.buckets[:newHead])
 			}
 		}
+
 		r.head = newHead
 
 		return

--- a/internal/status/probe_stats.go
+++ b/internal/status/probe_stats.go
@@ -127,6 +127,22 @@ func (t *RollingProbeTracker) Stats(period time.Duration, now time.Time) ProbeSt
 	return ProbeStats{}
 }
 
+// StatsAll returns probe results for every configured ring in construction
+// order, under a single lock acquisition. Use this for report generation to
+// ensure all periods reflect the same ring state.
+func (t *RollingProbeTracker) StatsAll(now time.Time) []ProbeStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	result := make([]ProbeStats, len(t.rings))
+
+	for i, ring := range t.rings {
+		result[i] = ring.statsSince(now.Add(-ring.period))
+	}
+
+	return result
+}
+
 // newestIdx returns the ring index of the newest bucket. Must be called with
 // the tracker lock held and count > 0.
 func (r *probeRing) newestIdx() int {

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func startOfThisMinute() time.Time {
@@ -258,4 +259,29 @@ func TestRollingProbeTracker_NonAlignedWindow(t *testing.T) {
 	ps = tracker.rings[0].statsSince(base.Add(-time.Second))
 	assert.Equal(t, 2, ps.Total)
 	assert.Equal(t, 0, ps.Failed)
+}
+
+func TestRollingProbeTracker_StatsAll(t *testing.T) {
+	now := time.Now()
+	tracker := NewRollingProbeTracker(
+		[]time.Duration{time.Minute, time.Hour},
+		BucketConfig{},
+	)
+
+	tracker.Record(false)
+	tracker.Record(true)
+
+	all := tracker.StatsAll(now.Add(time.Second))
+	require.Len(t, all, 2)
+	assert.Equal(t, 2, all[0].Total)
+	assert.Equal(t, 1, all[0].Failed)
+	assert.Equal(t, 2, all[1].Total)
+	assert.Equal(t, 1, all[1].Failed)
+}
+
+func TestRollingProbeTracker_StatsAll_Empty(t *testing.T) {
+	tracker := NewRollingProbeTracker([]time.Duration{time.Hour}, BucketConfig{})
+	all := tracker.StatsAll(time.Now())
+	require.Len(t, all, 1)
+	assert.Equal(t, 0, all[0].Total)
 }

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -81,14 +81,12 @@ func TestRollingProbeTracker_Empty(t *testing.T) {
 	assert.Equal(t, 0, ps.Failed)
 }
 
-func TestRollingProbeTracker_UnknownPeriod(t *testing.T) {
+func TestRollingProbeTracker_UnknownPeriod_Panics(t *testing.T) {
 	tracker := newSingleRingTracker(time.Hour, time.Minute)
 
 	tracker.Record(false)
 
-	ps := tracker.Stats(2*time.Hour, time.Now())
-	assert.Equal(t, 0, ps.Total)
-	assert.Equal(t, 0, ps.Failed)
+	assert.Panics(t, func() { tracker.Stats(2*time.Hour, time.Now()) })
 }
 
 func TestRollingProbeTracker_NoPeriods(t *testing.T) {
@@ -96,9 +94,7 @@ func TestRollingProbeTracker_NoPeriods(t *testing.T) {
 
 	tracker.Record(false)
 
-	ps := tracker.Stats(time.Hour, time.Now())
-	assert.Equal(t, 0, ps.Total)
-	assert.Equal(t, 0, ps.Failed)
+	assert.Panics(t, func() { tracker.Stats(time.Hour, time.Now()) })
 }
 
 func TestRollingProbeTracker_OutsideWindow(t *testing.T) {

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -244,13 +244,16 @@ func (s *Status) GenStatReport(periods []time.Duration) *Report {
 	rpt.Loop.TotalChecksRun = s.stateChangeTracker.updateCount
 
 	if s.rollingTracker != nil {
-		for idx, period := range periods {
-			ps := s.rollingTracker.Stats(period, generated)
+		allStats := s.rollingTracker.StatsAll(generated)
+		for idx := range min(len(allStats), len(rpt.Stats)) {
+			ps := allStats[idx]
 			rpt.Stats[idx].TotalProbes = ps.Total
-
 			rpt.Stats[idx].FailedProbes = ps.Failed
+
 			if ps.Total > 0 {
 				rpt.Stats[idx].FailureRate = ReadablePercent(float64(ps.Failed) / float64(ps.Total))
+			} else {
+				rpt.Stats[idx].FailureRate = ReadablePercent(-1)
 			}
 		}
 	}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -223,7 +223,7 @@ func TestGenStatReport_FailureRateNotComputed_WhenNoProbes(t *testing.T) {
 	rpt := s.GenStatReport([]time.Duration{time.Minute})
 	require.Len(t, rpt.Stats, 1)
 	assert.Equal(t, 0, rpt.Stats[0].TotalProbes)
-	assert.Equal(t, ReadablePercent(-1), rpt.Stats[0].FailureRate)
+	assert.InDelta(t, float64(-1), float64(rpt.Stats[0].FailureRate), 0.0001)
 }
 
 func TestGenStatReport_FailureRateComputed_WhenProbesExist(t *testing.T) {
@@ -241,5 +241,5 @@ func TestGenStatReport_FailureRateComputed_WhenProbesExist(t *testing.T) {
 	require.Len(t, rpt.Stats, 1)
 	assert.Equal(t, 2, rpt.Stats[0].TotalProbes)
 	assert.Equal(t, 1, rpt.Stats[0].FailedProbes)
-	assert.Equal(t, ReadablePercent(0.5), rpt.Stats[0].FailureRate)
+	assert.InDelta(t, 0.5, float64(rpt.Stats[0].FailureRate), 0.0001)
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -210,3 +210,36 @@ func TestSetNextCheckAt_ConcurrentAccess(t *testing.T) {
 	<-done
 	<-done
 }
+
+func TestGenStatReport_FailureRateNotComputed_WhenNoProbes(t *testing.T) {
+	s := NewStatus()
+	s.SetRetention(time.Hour)
+	s.Update(true)
+
+	tracker := NewRollingProbeTracker([]time.Duration{time.Minute}, BucketConfig{})
+	s.SetRollingTracker(tracker)
+
+	// No probes recorded yet.
+	rpt := s.GenStatReport([]time.Duration{time.Minute})
+	require.Len(t, rpt.Stats, 1)
+	assert.Equal(t, 0, rpt.Stats[0].TotalProbes)
+	assert.Equal(t, ReadablePercent(-1), rpt.Stats[0].FailureRate)
+}
+
+func TestGenStatReport_FailureRateComputed_WhenProbesExist(t *testing.T) {
+	s := NewStatus()
+	s.SetRetention(time.Hour)
+	s.Update(true)
+
+	tracker := NewRollingProbeTracker([]time.Duration{time.Minute}, BucketConfig{})
+	s.SetRollingTracker(tracker)
+
+	tracker.Record(false)
+	tracker.Record(true)
+
+	rpt := s.GenStatReport([]time.Duration{time.Minute})
+	require.Len(t, rpt.Stats, 1)
+	assert.Equal(t, 2, rpt.Stats[0].TotalProbes)
+	assert.Equal(t, 1, rpt.Stats[0].FailedProbes)
+	assert.Equal(t, ReadablePercent(0.5), rpt.Stats[0].FailureRate)
+}

--- a/internal/status/utils.go
+++ b/internal/status/utils.go
@@ -29,6 +29,10 @@ const (
 	TrailingZeroHSuffix = "h0m"
 	// TrailingZeroHMSuffix is the trailing zero hours/minutes suffix.
 	TrailingZeroHMSuffix = "0m"
+
+	// NotComputedDuration is the sentinel value for ReadableDuration that
+	// serialises as "Not computed" rather than a duration string.
+	NotComputedDuration ReadableDuration = -1
 )
 
 // MarshalJSON formats the percentage for JSON output.
@@ -56,5 +60,9 @@ func formatDuration(d time.Duration) string {
 
 // MarshalJSON formats the duration for JSON output.
 func (d ReadableDuration) MarshalJSON() ([]byte, error) {
+	if d == NotComputedDuration {
+		return json.Marshal(NotComputedMsg) //nolint:wrapcheck
+	}
+
 	return json.Marshal(formatDuration(time.Duration(d))) //nolint:wrapcheck
 }


### PR DESCRIPTION
- **fix(stats): remove dead ProbeStats.Coverage field**
- **fix(stats): atomic multi-period snapshot + consistent FailureRate sentinel**
- **fix(report): emit "Not computed" for Downtime when period exceeds retention**
- **fix(stats): guard against coverage ≤ 0 in CalculateUptime**
- **fix(stats): panic on unknown period in Stats() instead of silent zero**
- **perf(stats): batch-clear evicted buckets in advanceTo**
- **fix(test): use InDelta for float assertions to satisfy testifylint**
