### PR TITLE
s5 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,50 +40,20 @@ GLOBAL OPTIONS:
 
 Configuration by default is located in `.upd.toml` in the working directory.
 
-An example is:
+See [`upd.toml`](upd.toml) for a complete, runnable example. Values can
+reference environment variables with `${VAR}` syntax, e.g.:
 
 ```toml
-[checks]
-timeout = "2s"
-
 [checks.every]
-# Will be retrieved from env vars
 normal = "${UPD_NORMAL_CHECK}"
 down = "${UPD_DOWN_CHECK}"
+```
 
-[checks.list]
-ordered = [
-  # From https://en.wikipedia.org/wiki/Captive_portal
-  "http://10.10.1.4/",
-  "http://captive.apple.com/hotspot-detect.html",
-  "http://connectivitycheck.gstatic.com/generate_204",
-]
-shuffled = [
-  "http://clients3.google.com/generate_204",
-  "http://www.msftconnecttest.com/connecttest.txt",
-  "tcp://1.1.1.1:53/",
-  "tcp://1.0.0.1:53/",
-  "tcp://8.8.8.8:53/",
-  "tcp://8.8.4.4:53/",
-  "dns://1.1.1.1/www.google.com",
-]
+Probe-stat bucket granularity per report period is also tunable: each report
+period is split into at least `min` buckets (default 100), and a single
+bucket never aggregates more than `maxSpan` (default 30m):
 
-[downAction]
-exec = "cowsay"
-stopExec = "./testdata/echo-reboot-count.sh"
-
-[downAction.every]
-after = "1s"
-repeat = "3s"
-
-[stats]
-port = 8080
-retention = "10080m"
-reports = ["10s", "15m", "60m", "1440m", "10080m"]
-
-# Optional: probe-stat bucket granularity per report period.
-# Each report period is split into at least `min` buckets (default 100),
-# and a single bucket never aggregates more than `maxSpan` (default 30m).
+```toml
 [stats.buckets]
 min = 100
 maxSpan = "30m"

--- a/internal/check/probe_dns.go
+++ b/internal/check/probe_dns.go
@@ -29,9 +29,8 @@ var (
 	// ErrDNSMissingResolver is returned when no resolver is specified.
 	ErrDNSMissingResolver = errors.New("DNS probe missing resolver")
 	// ErrDNSNoAddresses is returned when a lookup succeeds but returns no
-	// addresses. The standard resolver never does this (an empty result is
-	// itself reported as an error), but the DNSResolver interface is
-	// injectable and a custom implementation could.
+	// addresses. The standard resolver never does this, but a custom
+	// injected DNSResolver could.
 	ErrDNSNoAddresses = errors.New("DNS lookup returned no addresses")
 )
 

--- a/internal/check/probe_dns.go
+++ b/internal/check/probe_dns.go
@@ -28,6 +28,11 @@ var (
 	ErrDNSMissingDomain = errors.New("DNS probe missing domain")
 	// ErrDNSMissingResolver is returned when no resolver is specified.
 	ErrDNSMissingResolver = errors.New("DNS probe missing resolver")
+	// ErrDNSNoAddresses is returned when a lookup succeeds but returns no
+	// addresses. The standard resolver never does this (an empty result is
+	// itself reported as an error), but the DNSResolver interface is
+	// injectable and a custom implementation could.
+	ErrDNSNoAddresses = errors.New("DNS lookup returned no addresses")
 )
 
 // NewDNSProbe creates a new DNS probe for the given resolver host (host:port
@@ -86,6 +91,12 @@ func (p DNSProbe) Execute(ctx context.Context, timeout time.Duration) *Report {
 	report := BuildReport(p, start)
 	if err != nil {
 		report.error = fmt.Errorf("error resolving %s: %w", p.Domain, err)
+
+		return report
+	}
+
+	if len(addr) == 0 {
+		report.error = fmt.Errorf("error resolving %s: %w", p.Domain, ErrDNSNoAddresses)
 
 		return report
 	}

--- a/internal/check/probe_dns_test.go
+++ b/internal/check/probe_dns_test.go
@@ -118,6 +118,19 @@ func TestDnsProbe(t *testing.T) {
 		assert.True(t, strings.HasPrefix(got, "error resolving invalid.aa"),
 			"got %q, want prefix %q", got, "error resolving invalid.aa")
 	})
+	t.Run(
+		"returns an error instead of panicking when the resolver returns no addresses",
+		func(t *testing.T) {
+			resolver := &fakeResolver{result: []string{}}
+			dnsProbe := &DNSProbe{Domain: testDomain, resolver: resolver}
+
+			require.NotPanics(t, func() {
+				report := dnsProbe.Execute(t.Context(), testTimeout)
+				err := checkError(t, report)
+				require.ErrorIs(t, err, ErrDNSNoAddresses)
+			})
+		},
+	)
 	t.Run("returns an error if the request times out", func(t *testing.T) {
 		resolver := &fakeResolver{err: context.DeadlineExceeded}
 		dnsProbe := &DNSProbe{Domain: "example.com", resolver: resolver}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,6 +234,10 @@ func probeFromURL(parsedURL *url.URL) (check.Probe, error) {
 	case check.HTTP, check.HTTPS:
 		return check.NewHTTPProbe(parsedURL.String()), nil
 	case check.TCP:
+		if parsedURL.Port() == "" {
+			return nil, fmt.Errorf("%w: missing port", errInvalidURI)
+		}
+
 		return check.NewTCPProbe(net.JoinHostPort(parsedURL.Hostname(), parsedURL.Port())), nil
 	default:
 		return nil, fmt.Errorf("%w: %q", errUnsupportedScheme, parsedURL.Scheme)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -154,12 +154,11 @@ func TestDNSCheckValidation_MissingDomain(t *testing.T) {
 }
 
 func TestDNSCheckValidation_MissingResolver(t *testing.T) {
-	conf, err := readTestConfig("upd_test_dns_missing_resolver.toml")
-	require.NoError(t, err)
-
-	_, checkErr := conf.GetChecks()
-	require.Error(t, checkErr)
-	assert.ErrorIs(t, checkErr, check.ErrDNSMissingResolver)
+	// validateURIs now builds the same probe GetChecks would, so a missing
+	// resolver is caught at validation time rather than deferred to GetChecks.
+	_, err := readTestConfig("upd_test_dns_missing_resolver.toml")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, check.ErrDNSMissingResolver)
 }
 
 func TestLogSetup(t *testing.T) {

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -17,6 +17,7 @@ var (
 	errInvalidLogLevel        = errors.New("must be one of: debug, info, warn")
 	errUnsupportedScheme      = errors.New("unsupported scheme")
 	errTooManyBuckets         = errors.New("report period needs too many buckets")
+	errMissingExec            = errors.New("required when downAction is configured")
 )
 
 func appendErr(errs []error, key string, err error) []error {
@@ -56,6 +57,10 @@ func (c Configuration) validateChecks() error {
 
 func (c Configuration) validateDownAction() error {
 	var errs []error
+
+	if c.DownAction != (DownActionConfig{}) && c.DownAction.Exec == "" {
+		errs = appendErr(errs, "exec", errMissingExec)
+	}
 
 	errs = appendErr(errs, "every.after", checkNonNegative(time.Duration(c.DownAction.Every.After)))
 	errs = appendErr(

--- a/internal/config/config_validate.go
+++ b/internal/config/config_validate.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/hugoh/upd/internal/check"
 	"github.com/hugoh/upd/internal/status"
 )
 
@@ -159,7 +158,6 @@ func validateURIs(uris []string) error {
 	var errs []error
 
 	for idx, uri := range uris {
-		// Same parser as GetChecksCat so validation matches what gets built.
 		parsed, err := url.Parse(uri)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("[%d]: %w", idx, errInvalidURI))
@@ -167,13 +165,10 @@ func validateURIs(uris []string) error {
 			continue
 		}
 
-		switch parsed.Scheme {
-		case check.DNS, check.HTTP, check.HTTPS, check.TCP:
-		default:
-			errs = append(
-				errs,
-				fmt.Errorf("[%d]: %w: %q", idx, errUnsupportedScheme, parsed.Scheme),
-			)
+		// Validate by attempting the same construction GetChecksCat performs,
+		// so a config that passes validation is guaranteed to build.
+		if _, err := probeFromURL(parsed); err != nil {
+			errs = append(errs, fmt.Errorf("[%d]: %w", idx, err))
 		}
 	}
 

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -120,6 +120,38 @@ shuffled = ["http://example.com/", "://invalid"]`)
 	assert.Contains(t, err.Error(), "missing required attributes")
 }
 
+func TestValidate_tcpMissingPort(t *testing.T) {
+	path := writeTestConfig(t, `[checks]
+timeout = "2000ms"
+
+[checks.every]
+normal = "120s"
+down = "20s"
+
+[checks.list]
+ordered = ["tcp://example.com"]`)
+
+	_, err := ReadConf(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required attributes")
+}
+
+func TestValidate_dnsMissingDomain(t *testing.T) {
+	path := writeTestConfig(t, `[checks]
+timeout = "2000ms"
+
+[checks.every]
+normal = "120s"
+down = "20s"
+
+[checks.list]
+ordered = ["dns://8.8.8.8"]`)
+
+	_, err := ReadConf(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required attributes")
+}
+
 func TestValidate_afterNegative(t *testing.T) {
 	config := validConfigBase() + `
 

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,16 +21,22 @@ func writeTestConfig(t *testing.T, content string) string {
 	return path
 }
 
-func validConfigBase() string {
-	return `[checks]
-timeout = "2000ms"
+// checksConfig builds a [checks] block with the given timeout and
+// [checks.list] body (e.g. `ordered = [...]` or `shuffled = [...]`).
+func checksConfig(timeout, listBody string) string {
+	return fmt.Sprintf(`[checks]
+timeout = %q
 
 [checks.every]
 normal = "120s"
 down = "20s"
 
 [checks.list]
-ordered = ["http://example.com/"]`
+%s`, timeout, listBody)
+}
+
+func validConfigBase() string {
+	return checksConfig("2000ms", `ordered = ["http://example.com/"]`)
 }
 
 func TestValidate_missingChecks(t *testing.T) {
@@ -73,15 +80,7 @@ ordered = ["http://example.com/"]`)
 }
 
 func TestValidate_timeoutZero(t *testing.T) {
-	path := writeTestConfig(t, `[checks]
-timeout = "0s"
-
-[checks.every]
-normal = "120s"
-down = "20s"
-
-[checks.list]
-ordered = ["http://example.com/"]`)
+	path := writeTestConfig(t, checksConfig("0s", `ordered = ["http://example.com/"]`))
 
 	_, err := ReadConf(path)
 	require.Error(t, err)
@@ -89,15 +88,10 @@ ordered = ["http://example.com/"]`)
 }
 
 func TestValidate_orderedInvalidURI(t *testing.T) {
-	path := writeTestConfig(t, `[checks]
-timeout = "2000ms"
-
-[checks.every]
-normal = "120s"
-down = "20s"
-
-[checks.list]
-ordered = ["http://example.com/", "://invalid"]`)
+	path := writeTestConfig(
+		t,
+		checksConfig("2000ms", `ordered = ["http://example.com/", "://invalid"]`),
+	)
 
 	_, err := ReadConf(path)
 	require.Error(t, err)
@@ -105,15 +99,10 @@ ordered = ["http://example.com/", "://invalid"]`)
 }
 
 func TestValidate_shuffledInvalidURI(t *testing.T) {
-	path := writeTestConfig(t, `[checks]
-timeout = "2000ms"
-
-[checks.every]
-normal = "120s"
-down = "20s"
-
-[checks.list]
-shuffled = ["http://example.com/", "://invalid"]`)
+	path := writeTestConfig(
+		t,
+		checksConfig("2000ms", `shuffled = ["http://example.com/", "://invalid"]`),
+	)
 
 	_, err := ReadConf(path)
 	require.Error(t, err)
@@ -121,15 +110,7 @@ shuffled = ["http://example.com/", "://invalid"]`)
 }
 
 func TestValidate_tcpMissingPort(t *testing.T) {
-	path := writeTestConfig(t, `[checks]
-timeout = "2000ms"
-
-[checks.every]
-normal = "120s"
-down = "20s"
-
-[checks.list]
-ordered = ["tcp://example.com"]`)
+	path := writeTestConfig(t, checksConfig("2000ms", `ordered = ["tcp://example.com"]`))
 
 	_, err := ReadConf(path)
 	require.Error(t, err)
@@ -137,15 +118,7 @@ ordered = ["tcp://example.com"]`)
 }
 
 func TestValidate_dnsMissingDomain(t *testing.T) {
-	path := writeTestConfig(t, `[checks]
-timeout = "2000ms"
-
-[checks.every]
-normal = "120s"
-down = "20s"
-
-[checks.list]
-ordered = ["dns://8.8.8.8"]`)
+	path := writeTestConfig(t, checksConfig("2000ms", `ordered = ["dns://8.8.8.8"]`))
 
 	_, err := ReadConf(path)
 	require.Error(t, err)
@@ -276,15 +249,7 @@ idleTimeout = "-5s"`
 func TestValidate_logLevelInvalid(t *testing.T) {
 	path := writeTestConfig(t, `logLevel = "invalid"
 
-[checks]
-timeout = "2000ms"
-
-[checks.every]
-normal = "120s"
-down = "20s"
-
-[checks.list]
-ordered = ["http://example.com/"]`)
+`+validConfigBase())
 
 	_, err := ReadConf(path)
 	require.Error(t, err)

--- a/internal/config/config_validate_test.go
+++ b/internal/config/config_validate_test.go
@@ -152,6 +152,20 @@ ordered = ["dns://8.8.8.8"]`)
 	assert.Contains(t, err.Error(), "missing required attributes")
 }
 
+func TestValidate_downActionMissingExec(t *testing.T) {
+	config := validConfigBase() + `
+
+[downAction.every]
+after = "60s"
+repeat = "300s"`
+	path := writeTestConfig(t, config)
+
+	_, err := ReadConf(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required attributes")
+	assert.Contains(t, err.Error(), "downAction: exec: required when downAction is configured")
+}
+
 func TestValidate_afterNegative(t *testing.T) {
 	config := validConfigBase() + `
 

--- a/internal/config/duration_test.go
+++ b/internal/config/duration_test.go
@@ -11,15 +11,18 @@ import (
 
 func TestDurationUnmarshalText(t *testing.T) {
 	tests := []struct {
-		name string
-		text string
-		want time.Duration
+		name    string
+		text    string
+		want    time.Duration
+		wantErr string
 	}{
-		{"seconds", "10s", 10 * time.Second},
-		{"minutes", "5m", 5 * time.Minute},
-		{"hours", "1h30m", 90 * time.Minute},
-		{"milliseconds", "500ms", 500 * time.Millisecond},
-		{"zero", "0s", 0},
+		{name: "seconds", text: "10s", want: 10 * time.Second},
+		{name: "minutes", text: "5m", want: 5 * time.Minute},
+		{name: "hours", text: "1h30m", want: 90 * time.Minute},
+		{name: "milliseconds", text: "500ms", want: 500 * time.Millisecond},
+		{name: "zero", text: "0s", want: 0},
+		{name: "invalid", text: "abc", wantErr: "invalid duration"},
+		{name: "empty", text: "", wantErr: "invalid duration"},
 	}
 
 	for _, tt := range tests {
@@ -27,30 +30,16 @@ func TestDurationUnmarshalText(t *testing.T) {
 			var d Duration
 
 			err := d.UnmarshalText([]byte(tt.text))
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+
+				return
+			}
+
 			require.NoError(t, err)
 			assert.Equal(t, Duration(tt.want), d)
 			assert.Equal(t, tt.want, d.StdDuration())
-		})
-	}
-}
-
-func TestDurationUnmarshalText_errors(t *testing.T) {
-	tests := []struct {
-		name    string
-		text    string
-		wantErr string
-	}{
-		{"invalid", "abc", "invalid duration"},
-		{"empty", "", "invalid duration"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var d Duration
-
-			err := d.UnmarshalText([]byte(tt.text))
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
 }

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -35,6 +35,7 @@ type DownActionLoop struct {
 	limitReached atomic.Bool
 	currentCmd   *exec.Cmd
 	cmdMu        sync.Mutex
+	done         chan struct{}
 }
 
 // StopExecTimeout bounds how long the stop command may run.
@@ -80,12 +81,18 @@ func (dal *DownActionLoop) Execute(ctx context.Context, execString string) error
 	return nil
 }
 
-// NewDownActionLoop creates a new loop context for the down action.
+// NewDownActionLoop creates a new loop context for the down action. done
+// starts closed since no run loop is running yet; Stop() must not block
+// waiting for a run loop that Start() never launched.
 func (da *DownAction) NewDownActionLoop(ctx context.Context) (*DownActionLoop, context.Context) {
 	ctx, cancelFunc := context.WithCancel(ctx)
+	done := make(chan struct{})
+	close(done)
+
 	dal := &DownActionLoop{
 		da:         da,
 		cancelFunc: cancelFunc,
+		done:       done,
 	}
 	dal.sleepTime.Store(int64(da.After))
 
@@ -95,6 +102,7 @@ func (da *DownAction) NewDownActionLoop(ctx context.Context) (*DownActionLoop, c
 // Start begins the down action loop in a goroutine.
 func (da *DownAction) Start(ctx context.Context) *DownActionLoop {
 	dal, ctx := da.NewDownActionLoop(ctx)
+	dal.done = make(chan struct{})
 
 	logger.DownAction().Debug("kicking off run loop")
 
@@ -103,12 +111,14 @@ func (da *DownAction) Start(ctx context.Context) *DownActionLoop {
 	return dal
 }
 
-// Stop cancels the down action loop, kills any running command, and runs the
-// stop command to completion. The stop command gets its own timeout-bounded
-// context so loop cancellation cannot kill it.
+// Stop cancels the down action loop, waits for the run loop goroutine to
+// exit so it cannot start a new command after Stop begins cleanup, kills any
+// running command, and runs the stop command to completion. The stop command
+// gets its own timeout-bounded context so loop cancellation cannot kill it.
 func (dal *DownActionLoop) Stop(_ context.Context) {
 	logger.DownAction().Debug("sending shutdown signal")
 	dal.cancelFunc()
+	<-dal.done
 	dal.killCurrentCmd()
 
 	if dal.da.StopExec != "" {
@@ -252,6 +262,8 @@ func (dal *DownActionLoop) nextSleep() time.Duration {
 }
 
 func (dal *DownActionLoop) run(ctx context.Context) {
+	defer close(dal.done)
+
 	logger.DownAction().Debug("down action loop started")
 
 	for {
@@ -263,6 +275,16 @@ func (dal *DownActionLoop) run(ctx context.Context) {
 
 			return
 		case <-time.After(time.Duration(dal.sleepTime.Load())):
+		}
+
+		// select can race with cancellation: the timer case may be chosen
+		// even though ctx was just canceled. Re-check explicitly so Stop's
+		// <-dal.done wait is a reliable guarantee that no new command will
+		// be started after cancellation.
+		if ctx.Err() != nil {
+			logger.DownAction().Debug("canceled")
+
+			return
 		}
 
 		dal.killCurrentCmd()

--- a/internal/logic/downaction.go
+++ b/internal/logic/downaction.go
@@ -35,7 +35,9 @@ type DownActionLoop struct {
 	limitReached atomic.Bool
 	currentCmd   *exec.Cmd
 	cmdMu        sync.Mutex
-	done         chan struct{}
+	// zero value means "nothing to wait for", so Stop() works even if
+	// Start() was never called.
+	runWG sync.WaitGroup
 }
 
 // StopExecTimeout bounds how long the stop command may run.
@@ -81,18 +83,12 @@ func (dal *DownActionLoop) Execute(ctx context.Context, execString string) error
 	return nil
 }
 
-// NewDownActionLoop creates a new loop context for the down action. done
-// starts closed since no run loop is running yet; Stop() must not block
-// waiting for a run loop that Start() never launched.
+// NewDownActionLoop creates a new loop context for the down action.
 func (da *DownAction) NewDownActionLoop(ctx context.Context) (*DownActionLoop, context.Context) {
 	ctx, cancelFunc := context.WithCancel(ctx)
-	done := make(chan struct{})
-	close(done)
-
 	dal := &DownActionLoop{
 		da:         da,
 		cancelFunc: cancelFunc,
-		done:       done,
 	}
 	dal.sleepTime.Store(int64(da.After))
 
@@ -102,7 +98,7 @@ func (da *DownAction) NewDownActionLoop(ctx context.Context) (*DownActionLoop, c
 // Start begins the down action loop in a goroutine.
 func (da *DownAction) Start(ctx context.Context) *DownActionLoop {
 	dal, ctx := da.NewDownActionLoop(ctx)
-	dal.done = make(chan struct{})
+	dal.runWG.Add(1)
 
 	logger.DownAction().Debug("kicking off run loop")
 
@@ -111,14 +107,12 @@ func (da *DownAction) Start(ctx context.Context) *DownActionLoop {
 	return dal
 }
 
-// Stop cancels the down action loop, waits for the run loop goroutine to
-// exit so it cannot start a new command after Stop begins cleanup, kills any
-// running command, and runs the stop command to completion. The stop command
-// gets its own timeout-bounded context so loop cancellation cannot kill it.
+// Stop cancels the loop, waits for it to exit so it can't start a new
+// command during cleanup, then runs the stop command to completion.
 func (dal *DownActionLoop) Stop(_ context.Context) {
 	logger.DownAction().Debug("sending shutdown signal")
 	dal.cancelFunc()
-	<-dal.done
+	dal.runWG.Wait()
 	dal.killCurrentCmd()
 
 	if dal.da.StopExec != "" {
@@ -262,7 +256,7 @@ func (dal *DownActionLoop) nextSleep() time.Duration {
 }
 
 func (dal *DownActionLoop) run(ctx context.Context) {
-	defer close(dal.done)
+	defer dal.runWG.Done()
 
 	logger.DownAction().Debug("down action loop started")
 
@@ -277,10 +271,8 @@ func (dal *DownActionLoop) run(ctx context.Context) {
 		case <-time.After(time.Duration(dal.sleepTime.Load())):
 		}
 
-		// select can race with cancellation: the timer case may be chosen
-		// even though ctx was just canceled. Re-check explicitly so Stop's
-		// <-dal.done wait is a reliable guarantee that no new command will
-		// be started after cancellation.
+		// select can pick the timer case even though ctx is already done;
+		// re-check so Stop's runWG.Wait() guarantee actually holds.
 		if ctx.Err() != nil {
 			logger.DownAction().Debug("canceled")
 

--- a/internal/logic/downaction_test.go
+++ b/internal/logic/downaction_test.go
@@ -188,7 +188,7 @@ func Test_StopCancelsLoopCtx(t *testing.T) {
 
 // Test_Stop_WithoutStart verifies Stop() does not block when called on a
 // DownActionLoop created via NewDownActionLoop but never Start()-ed, i.e.
-// with no run() goroutine to eventually close dal.done.
+// with no run() goroutine to eventually signal dal.runWG.
 func Test_Stop_WithoutStart(t *testing.T) {
 	da := &DownAction{}
 	dal, _ := da.NewDownActionLoop(t.Context())

--- a/internal/logic/downaction_test.go
+++ b/internal/logic/downaction_test.go
@@ -159,15 +159,16 @@ func Test_ExecuteReplacesStaleCmd(t *testing.T) {
 	assert.Nil(t, dal.currentCmd)
 	dal.cmdMu.Unlock()
 
-	err := dal.Execute(t.Context(), "true")
+	// "sleep" (not "true") so the process is still running when we check
+	// currentCmd below -- an instantly-exiting command races against
+	// waitForCmd's goroutine clearing currentCmd once it reaps the process.
+	err := dal.Execute(t.Context(), "sleep 1")
 	require.NoError(t, err)
 
 	dal.cmdMu.Lock()
 	require.NotNil(t, dal.currentCmd)
 	assert.NotEqual(t, firstPid, dal.currentCmd.Process.Pid, "Should track new process")
 	dal.cmdMu.Unlock()
-
-	time.Sleep(200 * time.Millisecond)
 }
 
 func Test_StopCancelsLoopCtx(t *testing.T) {

--- a/internal/logic/downaction_test.go
+++ b/internal/logic/downaction_test.go
@@ -92,6 +92,35 @@ func Test_Stop_RunsStopExecToCompletion(t *testing.T) {
 	require.NoError(t, err, "stop command should run to completion")
 }
 
+func Test_Stop_NoExecAfterStopExecStarted(t *testing.T) {
+	dir := t.TempDir()
+	stopStartedMarker := filepath.Join(dir, "stop-started")
+	violationMarker := filepath.Join(dir, "violation")
+
+	da := &DownAction{
+		After: 1 * time.Millisecond,
+		Every: 1 * time.Millisecond,
+		Exec: "sh -c 'if [ -f " + stopStartedMarker + " ]; then touch " +
+			violationMarker + "; fi'",
+		StopExec: "sh -c 'touch " + stopStartedMarker + " && sleep 0.1'",
+	}
+
+	dal := da.Start(t.Context())
+
+	// Let several Exec iterations fire before stopping, to give a would-be
+	// race between run()'s loop and Stop() a chance to manifest.
+	time.Sleep(15 * time.Millisecond)
+
+	dal.Stop(t.Context())
+
+	// Allow any Exec process started right before cancellation to finish.
+	time.Sleep(200 * time.Millisecond)
+
+	_, err := os.Stat(violationMarker)
+	assert.True(t, os.IsNotExist(err),
+		"Exec must never run once StopExec has started running")
+}
+
 func Test_killCurrentCmd_nilCmd(t *testing.T) {
 	da := &DownAction{}
 	dal, _ := da.NewDownActionLoop(t.Context())
@@ -154,6 +183,27 @@ func Test_StopCancelsLoopCtx(t *testing.T) {
 	case <-ctx.Done():
 	case <-timer.C:
 		t.Fatal("loop context should be cancelled after Stop")
+	}
+}
+
+// Test_Stop_WithoutStart verifies Stop() does not block when called on a
+// DownActionLoop created via NewDownActionLoop but never Start()-ed, i.e.
+// with no run() goroutine to eventually close dal.done.
+func Test_Stop_WithoutStart(t *testing.T) {
+	da := &DownAction{}
+	dal, _ := da.NewDownActionLoop(t.Context())
+
+	stopped := make(chan struct{})
+
+	go func() {
+		dal.Stop(t.Context())
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("Stop() blocked forever waiting for a run loop that was never started")
 	}
 }
 

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -201,7 +201,10 @@ func (l *Loop) Run(ctx context.Context, statServerConfig *status.StatServerConfi
 
 	for {
 		checkStatus := check.CheckerRun(ctx, checker, l.checkList.All())
-		l.lastSuccess = time.Now()
+		if checkStatus {
+			l.lastSuccess = time.Now()
+		}
+
 		l.ProcessCheck(ctx, checkStatus)
 
 		sleepTime := l.delays.ForStatus(l.status.Up)

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -81,6 +81,7 @@ package logic
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/hugoh/upd/internal/check"
@@ -108,6 +109,7 @@ type Loop struct {
 	checkList      *check.List
 	delays         Delays
 	downAction     *DownAction
+	downActionMu   sync.Mutex
 	downActionLoop *DownActionLoop
 	statServer     *status.StatServer
 	status         *status.Status
@@ -158,6 +160,9 @@ var ErrDownActionRunning = errors.New("cannot start new DownAction when one is a
 
 // DownActionStart initiates the down action execution loop.
 func (l *Loop) DownActionStart(ctx context.Context) error {
+	l.downActionMu.Lock()
+	defer l.downActionMu.Unlock()
+
 	if l.downActionLoop != nil {
 		return ErrDownActionRunning
 	}
@@ -167,15 +172,20 @@ func (l *Loop) DownActionStart(ctx context.Context) error {
 	return nil
 }
 
-// DownActionStop halts the current down action loop.
+// DownActionStop halts the current down action loop, blocking until its
+// StopExec command (if any) has run to completion.
 func (l *Loop) DownActionStop(ctx context.Context) {
-	if l.downActionLoop == nil {
+	l.downActionMu.Lock()
+	dal := l.downActionLoop
+	l.downActionLoop = nil
+	l.downActionMu.Unlock()
+
+	if dal == nil {
 		// Nothing to stop
 		return
 	}
 
-	l.downActionLoop.Stop(ctx)
-	l.downActionLoop = nil
+	dal.Stop(ctx)
 }
 
 // ProcessCheck handles state changes and triggers down actions.
@@ -230,13 +240,30 @@ func (l *Loop) Stop(ctx context.Context) {
 	}
 }
 
+func (l *Loop) currentDownActionLoop() *DownActionLoop {
+	l.downActionMu.Lock()
+	defer l.downActionMu.Unlock()
+
+	return l.downActionLoop
+}
+
 func (l *Loop) handleStateChange(ctx context.Context, upStatus bool) {
 	if l.downAction == nil {
 		return
 	}
 
 	if upStatus {
-		l.DownActionStop(ctx)
+		l.downActionMu.Lock()
+		dal := l.downActionLoop
+		l.downActionLoop = nil
+		l.downActionMu.Unlock()
+
+		if dal != nil {
+			// Run asynchronously: StopExec can take up to StopExecTimeout to
+			// complete, and must not block the check loop from running on
+			// schedule while it does.
+			go dal.Stop(ctx)
+		}
 	} else {
 		err := l.DownActionStart(ctx)
 		if err != nil {
@@ -257,8 +284,8 @@ func (l *Loop) pushStatus() {
 		l.status.SetLastSuccessAt(l.lastSuccess)
 	}
 
-	if l.downActionLoop != nil {
-		l.status.SetDownActionStatus(l.downActionLoop.Status())
+	if dal := l.currentDownActionLoop(); dal != nil {
+		l.status.SetDownActionStatus(dal.Status())
 	} else {
 		l.status.SetDownActionStatus(status.DownActionStatus{})
 	}

--- a/internal/logic/loop.go
+++ b/internal/logic/loop.go
@@ -259,9 +259,8 @@ func (l *Loop) handleStateChange(ctx context.Context, upStatus bool) {
 		l.downActionMu.Unlock()
 
 		if dal != nil {
-			// Run asynchronously: StopExec can take up to StopExecTimeout to
-			// complete, and must not block the check loop from running on
-			// schedule while it does.
+			// Async: StopExec can take up to StopExecTimeout and must not
+			// block the check loop.
 			go dal.Stop(ctx)
 		}
 	} else {

--- a/internal/logic/loop_run_test.go
+++ b/internal/logic/loop_run_test.go
@@ -10,22 +10,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRun_StopsOnContextCancel(t *testing.T) {
+// newTestLoop builds and configures a Loop for tests that drive Run/Stop
+// directly, keeping the check-list/delays/periods setup out of each test.
+func newTestLoop(
+	t *testing.T,
+	checkList *check.List,
+	delays Delays,
+	periods ...time.Duration,
+) *Loop {
+	t.Helper()
+
 	loop := NewLoop()
-	emptyCheckList := &check.List{}
-	loop.Configure(
-		emptyCheckList,
-		Delays{Up: 1 * time.Second, Down: 1 * time.Second},
-		nil,
-		status.BucketConfig{},
-	)
+	loop.Configure(checkList, delays, nil, status.BucketConfig{}, periods...)
+
+	return loop
+}
+
+// runLoopAsync starts loop.Run in a goroutine bound to a cancelable context
+// and returns the cancel func; the context is also canceled on test cleanup.
+func runLoopAsync(t *testing.T, loop *Loop) context.CancelFunc {
+	t.Helper()
 
 	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	t.Cleanup(cancel)
 
 	go func() {
 		loop.Run(ctx, &status.StatServerConfig{})
 	}()
+
+	return cancel
+}
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	loop := newTestLoop(t, &check.List{}, Delays{Up: 1 * time.Second, Down: 1 * time.Second})
+	cancel := runLoopAsync(t, loop)
 
 	time.Sleep(50 * time.Millisecond)
 	cancel()
@@ -33,7 +51,6 @@ func TestRun_StopsOnContextCancel(t *testing.T) {
 }
 
 func TestRun_ProcessesChecks(t *testing.T) {
-	loop := NewLoop()
 	probe := check.Probe(check.NewHTTPProbe("http://example.invalid"))
 	dummyCheck := &check.Check{
 		Probe:   probe,
@@ -43,41 +60,25 @@ func TestRun_ProcessesChecks(t *testing.T) {
 		Ordered: check.Checks{dummyCheck},
 	}
 
-	loop.Configure(
+	loop := newTestLoop(
+		t,
 		checkList,
 		Delays{Up: 10 * time.Millisecond, Down: 10 * time.Millisecond},
-		nil,
-		status.BucketConfig{},
 	)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	go func() {
-		loop.Run(ctx, &status.StatServerConfig{})
-	}()
+	runLoopAsync(t, loop)
 
 	time.Sleep(100 * time.Millisecond)
 }
 
 func TestRun_DoesNotUpdateLastSuccessOnFailure(t *testing.T) {
-	loop := NewLoop()
 	// An empty check list means CheckerRun always returns false (no checks
 	// pass), simulating an outage on every iteration.
-	emptyCheckList := &check.List{}
-	loop.Configure(
-		emptyCheckList,
+	loop := newTestLoop(
+		t,
+		&check.List{},
 		Delays{Up: 10 * time.Millisecond, Down: 10 * time.Millisecond},
-		nil,
-		status.BucketConfig{},
 	)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-
-	go func() {
-		loop.Run(ctx, &status.StatServerConfig{})
-	}()
+	cancel := runLoopAsync(t, loop)
 
 	time.Sleep(100 * time.Millisecond)
 	cancel()
@@ -88,14 +89,7 @@ func TestRun_DoesNotUpdateLastSuccessOnFailure(t *testing.T) {
 }
 
 func TestStop_StopsStatServer(t *testing.T) {
-	loop := NewLoop()
-	emptyCheckList := &check.List{}
-	loop.Configure(
-		emptyCheckList,
-		Delays{Up: 1 * time.Second, Down: 1 * time.Second},
-		nil,
-		status.BucketConfig{},
-	)
+	loop := newTestLoop(t, &check.List{}, Delays{Up: 1 * time.Second, Down: 1 * time.Second})
 
 	ctx := t.Context()
 
@@ -107,16 +101,8 @@ func TestStop_StopsStatServer(t *testing.T) {
 }
 
 func TestRun_StopsTimerOnContextCancel(t *testing.T) {
-	loop := NewLoop()
-	emptyCheckList := &check.List{}
 	longDelay := 10 * time.Second
-	loop.Configure(
-		emptyCheckList,
-		Delays{Up: longDelay, Down: longDelay},
-		nil,
-		status.BucketConfig{},
-		0,
-	)
+	loop := newTestLoop(t, &check.List{}, Delays{Up: longDelay, Down: longDelay}, 0)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()

--- a/internal/logic/loop_run_test.go
+++ b/internal/logic/loop_run_test.go
@@ -60,6 +60,33 @@ func TestRun_ProcessesChecks(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 }
 
+func TestRun_DoesNotUpdateLastSuccessOnFailure(t *testing.T) {
+	loop := NewLoop()
+	// An empty check list means CheckerRun always returns false (no checks
+	// pass), simulating an outage on every iteration.
+	emptyCheckList := &check.List{}
+	loop.Configure(
+		emptyCheckList,
+		Delays{Up: 10 * time.Millisecond, Down: 10 * time.Millisecond},
+		nil,
+		status.BucketConfig{},
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		loop.Run(ctx, &status.StatServerConfig{})
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	assert.True(t, loop.lastSuccess.IsZero(),
+		"lastSuccess should never be set when every check fails")
+}
+
 func TestStop_StopsStatServer(t *testing.T) {
 	loop := NewLoop()
 	emptyCheckList := &check.List{}

--- a/internal/logic/loop_test.go
+++ b/internal/logic/loop_test.go
@@ -80,6 +80,34 @@ func Test_ProcessCheck_StatusChanged_UpStatus_StopsDownAction(t *testing.T) {
 	assert.Nil(t, loop.downActionLoop)
 }
 
+func Test_ProcessCheck_UpStatus_DoesNotBlockOnStopExec(t *testing.T) {
+	loop := emptyNewLoop()
+	ctx := t.Context()
+	da := &DownAction{
+		After:    time.Millisecond,
+		Exec:     testTrue,
+		StopExec: "sleep 5",
+	}
+	loop.downAction = da
+
+	require.NoError(t, loop.DownActionStart(ctx))
+	require.NotNil(t, loop.downActionLoop)
+
+	start := time.Now()
+
+	loop.ProcessCheck(ctx, true)
+
+	elapsed := time.Since(start)
+
+	assert.Nil(
+		t,
+		loop.downActionLoop,
+		"downActionLoop should be cleared synchronously even though StopExec runs in the background",
+	)
+	assert.Less(t, elapsed, time.Second,
+		"ProcessCheck should not block on a slow StopExec command")
+}
+
 func Test_ProcessCheck_StatusChanged_DownStatus_StartsDownAction(t *testing.T) {
 	loop := emptyNewLoop()
 	ctx := t.Context()

--- a/internal/status/probe_stats_test.go
+++ b/internal/status/probe_stats_test.go
@@ -22,6 +22,17 @@ func newSingleRingTracker(period, interval time.Duration) *RollingProbeTracker {
 	)
 }
 
+// recordBucketed locks tracker and records on rings[0] at each offset from
+// base, mirroring how Record() is normally called under the tracker's mutex.
+func recordBucketed(tracker *RollingProbeTracker, base time.Time, offsets ...time.Duration) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+
+	for _, offset := range offsets {
+		tracker.rings[0].recordAt(base.Add(offset))
+	}
+}
+
 func TestBucketConfig_Interval_Defaults(t *testing.T) {
 	var cfg BucketConfig
 
@@ -214,12 +225,8 @@ func TestRollingProbeTracker_AlignedWindow(t *testing.T) {
 
 	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
-	tracker.mu.Lock()
-	// Bucket [12:00:00, 12:00:05)
-	tracker.rings[0].recordAt(base.Add(4 * time.Second))
-	// Bucket [12:00:05, 12:00:10)
-	tracker.rings[0].recordAt(base.Add(9 * time.Second))
-	tracker.mu.Unlock()
+	// Bucket [12:00:00, 12:00:05) and bucket [12:00:05, 12:00:10)
+	recordBucketed(tracker, base, 4*time.Second, 9*time.Second)
 
 	// 1h window from 12:55:05 → cutoff = 12:00:05 (later bucket boundary)
 	ps := tracker.rings[0].statsSince(base.Add(5 * time.Second))
@@ -237,12 +244,8 @@ func TestRollingProbeTracker_NonAlignedWindow(t *testing.T) {
 
 	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
-	tracker.mu.Lock()
-	// Bucket [12:00:00, 12:00:05)
-	tracker.rings[0].recordAt(base.Add(4 * time.Second))
-	// Bucket [12:00:05, 12:00:10)
-	tracker.rings[0].recordAt(base.Add(6 * time.Second))
-	tracker.mu.Unlock()
+	// Bucket [12:00:00, 12:00:05) and bucket [12:00:05, 12:00:10)
+	recordBucketed(tracker, base, 4*time.Second, 6*time.Second)
 
 	// Cutoff = 12:00:03 (middle of first bucket):
 	// Bucket [12:00:00, 12:00:05): starts before cutoff → excluded

--- a/internal/status/report_test.go
+++ b/internal/status/report_test.go
@@ -34,6 +34,29 @@ func setupTestServer(t *testing.T, opts ...func(*StatServerConfig)) *StatHandler
 	return &StatHandler{statServer: server}
 }
 
+// setupUpHandler builds a test handler and marks the connection up.
+func setupUpHandler(t *testing.T, opts ...func(*StatServerConfig)) *StatHandler {
+	t.Helper()
+
+	handler := setupTestServer(t, opts...)
+	handler.statServer.status.Update(true)
+
+	return handler
+}
+
+// serveRequest sends a method request for StatRoute to handler and returns
+// the recorded response.
+func serveRequest(t *testing.T, handler *StatHandler, method string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(method, StatRoute, http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	return rec
+}
+
 func TestStatHandlerInit(t *testing.T) {
 	status := NewStatus()
 	status.SetRetention(1 * time.Hour)
@@ -54,14 +77,12 @@ func TestStatHandlerInit(t *testing.T) {
 }
 
 func TestStatHandler_GenStatReport(t *testing.T) {
-	handler := setupTestServer(t, func(c *StatServerConfig) {
+	handler := setupUpHandler(t, func(c *StatServerConfig) {
 		c.Reports = []time.Duration{
 			time.Minute,
 			5 * time.Minute,
 		}
 	})
-	status := handler.statServer.status
-	status.Update(true)
 
 	report := handler.GenStatReport()
 	require.NotNil(t, report)
@@ -88,14 +109,9 @@ func TestStatHandler_GenStatReport_WithChanges(t *testing.T) {
 }
 
 func TestStatHandler_ServeHTTP(t *testing.T) {
-	handler := setupTestServer(t)
-	status := handler.statServer.status
-	status.Update(true)
+	handler := setupUpHandler(t)
 
-	req := httptest.NewRequest(http.MethodGet, StatRoute, http.NoBody)
-	rec := httptest.NewRecorder()
-
-	handler.ServeHTTP(rec, req)
+	rec := serveRequest(t, handler, http.MethodGet)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
@@ -109,9 +125,7 @@ func TestStatHandler_ServeHTTP(t *testing.T) {
 }
 
 func TestStatHandler_ServeHTTP_MethodNotAllowed(t *testing.T) {
-	handler := setupTestServer(t)
-	status := handler.statServer.status
-	status.Update(true)
+	handler := setupUpHandler(t)
 
 	mux := http.NewServeMux()
 	mux.Handle("GET "+StatRoute, handler)
@@ -124,33 +138,39 @@ func TestStatHandler_ServeHTTP_MethodNotAllowed(t *testing.T) {
 }
 
 func TestStatHandler_ServeHTTP_MethodHead(t *testing.T) {
-	handler := setupTestServer(t)
-	status := handler.statServer.status
-	status.Update(true)
+	handler := setupUpHandler(t)
 
-	req := httptest.NewRequest(http.MethodHead, StatRoute, http.NoBody)
-	rec := httptest.NewRecorder()
-
-	handler.ServeHTTP(rec, req)
+	rec := serveRequest(t, handler, http.MethodHead)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestStatHandler_ServeHTTP_JSONFormat(t *testing.T) {
-	handler := setupTestServer(t)
-	status := handler.statServer.status
-	status.Update(true)
+	handler := setupUpHandler(t)
 
-	req := httptest.NewRequest(http.MethodGet, StatRoute, http.NoBody)
-	rec := httptest.NewRecorder()
-
-	handler.ServeHTTP(rec, req)
+	rec := serveRequest(t, handler, http.MethodGet)
 
 	body := rec.Body.String()
 	assert.Contains(t, body, `"isUp": true`)
 	assert.Contains(t, body, `"reports"`)
 	assert.Contains(t, body, `"loop"`)
 	assert.Contains(t, body, `"updVersion"`)
+}
+
+// marshalToMap round-trips v through JSON and returns it as a generic map,
+// for tests that assert on field names/values rather than the Go struct.
+func marshalToMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+
+	var raw map[string]any
+
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	return raw
 }
 
 func TestReportByPeriod_JSON_Marshal(t *testing.T) {
@@ -219,13 +239,7 @@ func TestReport_JSONFieldNames(t *testing.T) {
 		},
 	}
 
-	data, err := json.Marshal(report)
-	require.NoError(t, err)
-
-	var raw map[string]any
-
-	err = json.Unmarshal(data, &raw)
-	require.NoError(t, err)
+	raw := marshalToMap(t, report)
 
 	assert.Contains(t, raw, "isUp")
 	assert.Contains(t, raw, "reports")
@@ -281,13 +295,7 @@ func TestReport_SubStructFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err := json.Marshal(tt.obj)
-			require.NoError(t, err)
-
-			var raw map[string]any
-
-			err = json.Unmarshal(data, &raw)
-			require.NoError(t, err)
+			raw := marshalToMap(t, tt.obj)
 
 			for key, want := range tt.checks {
 				if f, ok := want.(float64); ok {
@@ -307,13 +315,7 @@ func TestReport_DownActionOmittedWhenNil(t *testing.T) {
 		Loop:    &LoopStatus{Interval: ReadableDuration(time.Minute)},
 	}
 
-	data, err := json.Marshal(report)
-	require.NoError(t, err)
-
-	var raw map[string]any
-
-	err = json.Unmarshal(data, &raw)
-	require.NoError(t, err)
+	raw := marshalToMap(t, report)
 
 	assert.NotContains(t, raw, "downAction")
 	assert.Contains(t, raw, "loop")

--- a/internal/status/stat-server_test.go
+++ b/internal/status/stat-server_test.go
@@ -32,6 +32,17 @@ func newStatServer(t *testing.T, config *StatServerConfig) *StatServer {
 	return server
 }
 
+// newDefaultStatServer starts a stat server with a standard test config
+// (fixed port, one report period).
+func newDefaultStatServer(t *testing.T) *StatServer {
+	t.Helper()
+
+	return newStatServer(t, &StatServerConfig{
+		Port:    18765,
+		Reports: []time.Duration{time.Minute},
+	})
+}
+
 func TestStartStatServer_NoPort(t *testing.T) {
 	status := NewStatus()
 	status.SetRetention(1 * time.Hour)
@@ -45,12 +56,7 @@ func TestStartStatServer_NoPort(t *testing.T) {
 }
 
 func TestStartStatServer_WithPort(t *testing.T) {
-	config := &StatServerConfig{
-		Port:    18765,
-		Reports: []time.Duration{time.Minute},
-	}
-
-	server := newStatServer(t, config)
+	server := newDefaultStatServer(t)
 	require.NotNil(t, server.status)
 	require.NotNil(t, server.config)
 }
@@ -72,12 +78,7 @@ func TestStatServer_Start_WithTimeouts(t *testing.T) {
 }
 
 func TestStatServer_Start_UsesDefaultTimeouts(t *testing.T) {
-	config := &StatServerConfig{
-		Port:    18765,
-		Reports: []time.Duration{time.Minute},
-	}
-
-	server := newStatServer(t, config)
+	server := newDefaultStatServer(t)
 	require.NotNil(t, server.server)
 	assert.Equal(t, DefaultStatServerReadTimeout, server.server.ReadTimeout)
 	assert.Equal(t, DefaultStatServerWriteTimeout, server.server.WriteTimeout)
@@ -94,22 +95,12 @@ func TestShutdown_NilServer(t *testing.T) {
 }
 
 func TestShutdown_GracefulShutdown(t *testing.T) {
-	config := &StatServerConfig{
-		Port:    18765,
-		Reports: []time.Duration{time.Minute},
-	}
-
-	server := newStatServer(t, config)
+	server := newDefaultStatServer(t)
 	require.NotNil(t, server.server)
 }
 
 func TestStatServer_Route(t *testing.T) {
-	config := &StatServerConfig{
-		Port:    18765,
-		Reports: []time.Duration{time.Minute},
-	}
-
-	server := newStatServer(t, config)
+	server := newDefaultStatServer(t)
 	require.NotNil(t, server.server)
 
 	url := "http://localhost" + server.server.Addr + StatRoute

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -211,13 +211,21 @@ func TestSetNextCheckAt_ConcurrentAccess(t *testing.T) {
 	<-done
 }
 
-func TestGenStatReport_FailureRateNotComputed_WhenNoProbes(t *testing.T) {
+// newStatusWithTracker builds a Status with a one-period rolling tracker
+// attached and the connection marked up.
+func newStatusWithTracker() (*Status, *RollingProbeTracker) {
 	s := NewStatus()
 	s.SetRetention(time.Hour)
 	s.Update(true)
 
 	tracker := NewRollingProbeTracker([]time.Duration{time.Minute}, BucketConfig{})
 	s.SetRollingTracker(tracker)
+
+	return s, tracker
+}
+
+func TestGenStatReport_FailureRateNotComputed_WhenNoProbes(t *testing.T) {
+	s, _ := newStatusWithTracker()
 
 	// No probes recorded yet.
 	rpt := s.GenStatReport([]time.Duration{time.Minute})
@@ -227,12 +235,7 @@ func TestGenStatReport_FailureRateNotComputed_WhenNoProbes(t *testing.T) {
 }
 
 func TestGenStatReport_FailureRateComputed_WhenProbesExist(t *testing.T) {
-	s := NewStatus()
-	s.SetRetention(time.Hour)
-	s.Update(true)
-
-	tracker := NewRollingProbeTracker([]time.Duration{time.Minute}, BucketConfig{})
-	s.SetRollingTracker(tracker)
+	s, tracker := newStatusWithTracker()
 
 	tracker.Record(false)
 	tracker.Record(true)

--- a/internal/status/utils_test.go
+++ b/internal/status/utils_test.go
@@ -24,38 +24,21 @@ func Test_FormatDuration(t *testing.T) {
 	assert.Equal(t, "1h1m1s", formatDuration(time.Hour+time.Minute+time.Second))
 }
 
-func TestReadablePercent_MarshalJSON(t *testing.T) {
+func TestReadableTypes_MarshalJSON(t *testing.T) {
 	tests := []struct {
 		name     string
-		value    ReadablePercent
+		value    any
 		expected string
 	}{
-		{"zero percent", 0.0, `"0.00 %"`},
-		{"fifty percent", 0.5, `"50.00 %"`},
-		{"hundred percent", 1.0, `"100.00 %"`},
-		{"not computed", -1.0, `"Not computed"`},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			data, err := json.Marshal(tt.value)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, string(data))
-		})
-	}
-}
-
-func TestReadableDuration_MarshalJSON(t *testing.T) {
-	tests := []struct {
-		name     string
-		value    ReadableDuration
-		expected string
-	}{
-		{"zero", 0, `"0s"`},
-		{"one second", ReadableDuration(time.Second), `"1s"`},
-		{"one minute", ReadableDuration(time.Minute), `"1m"`},
-		{"one hour", ReadableDuration(time.Hour), `"1h"`},
-		{"complex", ReadableDuration(time.Hour + time.Minute + time.Second), `"1h1m1s"`},
+		{"percent zero", ReadablePercent(0.0), `"0.00 %"`},
+		{"percent fifty", ReadablePercent(0.5), `"50.00 %"`},
+		{"percent hundred", ReadablePercent(1.0), `"100.00 %"`},
+		{"percent not computed", ReadablePercent(-1.0), `"Not computed"`},
+		{"duration zero", ReadableDuration(0), `"0s"`},
+		{"duration one second", ReadableDuration(time.Second), `"1s"`},
+		{"duration one minute", ReadableDuration(time.Minute), `"1m"`},
+		{"duration one hour", ReadableDuration(time.Hour), `"1h"`},
+		{"duration complex", ReadableDuration(time.Hour + time.Minute + time.Second), `"1h1m1s"`},
 	}
 
 	for _, tt := range tests {

--- a/testdata/upd_test_noda.toml
+++ b/testdata/upd_test_noda.toml
@@ -14,4 +14,9 @@ ordered = [
   "http://clients3.google.com/generate_204",
   "http://www.msftconnecttest.com/connecttest.txt",
 ]
-shuffled = ["dns://1.1.1.1/", "dns://1.0.0.1/", "dns://8.8.8.8/", "dns://8.8.4.4/"]
+shuffled = [
+  "dns://1.1.1.1/www.google.com",
+  "dns://1.0.0.1/www.google.com",
+  "dns://8.8.8.8/www.google.com",
+  "dns://8.8.4.4/www.google.com",
+]


### PR DESCRIPTION
- **fix(logic): only update lastSuccess when a check actually succeeds**
- **fix(logic): make DownActionLoop.Stop wait for the run loop to exit**
- **fix(logic): run StopExec asynchronously so it can't stall the check loop**
- **fix(config): validate check URIs by building the real probe**
- **fix(config): reject a downAction section with no exec command**
- **fix(check): guard DNS probe against an empty resolver result**
- **docs: trim verbose comments to their load-bearing point**
- **refactor(logic): replace done channel with sync.WaitGroup**
