### PR TITLE
chore: consolidate shared tooling via go-tools

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,0 +1,36 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+_commit: 528783e
+_src_path: gh:hugoh/go-tools
+codecov_ignore:
+- internal/version
+codecov_style: simple
+cog_omit_type: lint
+coverage_backends_override: false
+coverage_total: 80
+dev_watch: false
+dprint_has_excludes: true
+golangci_extra_disable:
+- depguard
+- exhaustruct
+- godoclint
+- testpackage
+golangci_extra_exclusions: []
+golangci_revive_overrides: false
+golangci_test_exclude_linters:
+- err113
+- noctx
+- varnamelen
+goreleaser_version_pkg: github.com/hugoh/upd/internal/version
+has_fuzz: false
+has_gen: false
+has_goreleaser: true
+has_homebrew_cask: false
+has_test_int: true
+hk_has_golangci_step: true
+hk_has_goreleaser_step: false
+hk_prepush_with_go_ci: false
+project_description: Tool to monitor if the network connection is up
+project_name: upd
+test_int_cmd: gotestsum -- -race -tags=integration ./...
+testcoverage_excludes: []
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,128 +11,22 @@ permissions: {}
 
 jobs:
   hk:
-    timeout-minutes: 30
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@528783e852e2e696f210acc4441b4c5983d396b0
     permissions:
       contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - &checkout-full
-        name: Checkout code with full history
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-      - &mise
-        name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
-      - name: hk checks
-        run: hk check --no-progress --profile ci --all
-      - name: Display hk log on failure
-        if: failure()
-        run: cat /home/runner/.local/state/hk/output.log
 
   goci:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@528783e852e2e696f210acc4441b4c5983d396b0
     permissions:
       contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          persist-credentials: false
-      - &go-version
-        name: Get Go version
-        id: go-version
-        run: |
-          GO_VERSION=$(grep '^go ' mise.toml | sed 's/.*"\(.*\)"/\1/')
-          echo "go=${GO_VERSION}" >> "$GITHUB_OUTPUT"
-      - &go-cache
-        name: Cache Go modules
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ steps.go-version.outputs.go }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ steps.go-version.outputs.go }}-
-      - *mise
-      - name: Mise CI
-        run: mise ci
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   release:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
     needs: [hk, goci]
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@528783e852e2e696f210acc4441b4c5983d396b0
     permissions:
       contents: write
-    steps:
-      - *checkout-full
-      - *go-version
-      - *go-cache
-      - *mise
-      - name: Semver release
-        if: github.event_name == 'push'
-        uses: cocogitto/cocogitto-action@9a9fe03b31c47444290c0d7f9b1ee1b44ee13f20
-        with:
-          command: bump
-          args: --auto
-      - name: Validate release
-        id: validate
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          goreleaser check
-          if [ "${{ github.event_name }}" != "push" ]; then
-            echo "--- Dry-run: version preview ---"
-            cog bump --auto --dry-run --skip-untracked || echo "(no version bump needed)"
-            echo ""
-            echo "--- Validating GITHUB_TOKEN setup ---"
-            if [ -z "$GITHUB_TOKEN" ]; then
-              echo "FAIL: GITHUB_TOKEN is not set"
-              exit 1
-            fi
-            echo "✓ GITHUB_TOKEN is set"
-            if [ -z "$GITHUB_REPOSITORY" ]; then
-              echo "FAIL: GITHUB_REPOSITORY is not set"
-              exit 1
-            fi
-            echo "✓ GITHUB_REPOSITORY is ${GITHUB_REPOSITORY}"
-            REMOTE_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
-            echo "${REMOTE_URL}" | grep -Eq '^https://x-access-token:.+@github\.com/.+/.+' || {
-              echo "FAIL: remote URL format is invalid"
-              exit 1
-            }
-            echo "✓ Remote URL format is valid"
-            git ls-remote "${REMOTE_URL}" HEAD > /dev/null
-            echo "✓ Git remote is accessible (token + URL work)"
-            echo ""
-            echo "Dry-run complete — no tag pushed or released"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          TAG=$(git tag --points-at HEAD | head -1)
-          if [ -z "$TAG" ]; then
-            echo "No tag at HEAD — skipping release"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-      - name: Push tag and Release
-        if: steps.validate.outputs.skip != 'true'
-        env:
-          TAG: ${{ steps.validate.outputs.tag }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-        run: |
-          echo "Pushing ${TAG}"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
-          git push origin "${TAG}"
-          echo "Releasing ${TAG}"
-          goreleaser release --clean
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      tap_github_token: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -1,0 +1,20 @@
+---
+name: Update from go-tools template
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  repository_dispatch:
+    types: [go-tools-updated]
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  update:
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@528783e852e2e696f210acc4441b4c5983d396b0
+    permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,12 +2,12 @@ version: "2"
 linters:
   default: all
   disable:
-    - depguard
-    - exhaustruct
-    - godoclint
     - gomodguard
     - noinlineerr
     - paralleltest
+    - depguard
+    - exhaustruct
+    - godoclint
     - testpackage
     - wsl
   exclusions:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,6 @@ nfpms:
       - deb
       - rpm
     bindir: /usr/bin
-
 changelog:
   use: git
   sort: asc

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,34 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "customManagers:githubActionsVersions",
-    ":automergeLinters",
-    ":automergeMinor",
-    ":automergeDigest",
-    "schedule:monthly"
-  ],
-  "minimumReleaseAge": "7 days",
-  "vulnerabilityAlerts": {
-    "labels": ["security"],
-    "automerge": true,
-    "schedule": ["at any time"]
-  },
-  "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "Go dependencies"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "groupName": "Major updates",
-      "automerge": false
-    }
-  ],
-  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
+  "extends": ["github>hugoh/go-tools"]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -8,6 +8,7 @@
   "yaml": {
   },
   "excludes": [
+    ".copier-answers.yml",
     "**/*-lock.json"
   ],
   "plugins": [

--- a/hk.pkl
+++ b/hk.pkl
@@ -30,9 +30,9 @@ hooks {
     stash = "git"
     steps = linters
   }
-["pre-push"] {
-        steps = linters
-    }
+  ["pre-push"] {
+    steps = linters
+  }
   ["fix"] {
     fix = true
     steps = linters

--- a/mise-tasks/build
+++ b/mise-tasks/build
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Build application"
+#MISE sources=["**/*.go", "go.mod", "go.sum"]
+go build -o "dist/$(basename "$(go list -m | sed -E 's|/v[0-9]+$||')")" .

--- a/mise-tasks/ci
+++ b/mise-tasks/ci
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Run full CI pipeline (lint, tests, coverage, build)"
+#MISE depends=["lint", "ci-core", "build"]
+true

--- a/mise-tasks/ci-core
+++ b/mise-tasks/ci-core
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Run core CI checks (test, coverage, integration)"
+#MISE depends=["coverage", "test-int"]
+true

--- a/mise-tasks/clean
+++ b/mise-tasks/clean
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Clean the project"
+go clean
+rm -f "${COVEROUT}"

--- a/mise-tasks/coverage
+++ b/mise-tasks/coverage
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Check test coverage"
+#MISE depends=["test"]
+go-test-coverage -config .testcoverage.yml

--- a/mise-tasks/depup
+++ b/mise-tasks/depup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Upgrade dependencies"
+set -e
+go get -u -t ./...
+go mod tidy -v

--- a/mise-tasks/dev
+++ b/mise-tasks/dev
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+#MISE description="Development mode"
+go run . "$@"

--- a/mise-tasks/fix
+++ b/mise-tasks/fix
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Lint and fix code"
+set -e
+mise run lint-mod
+mise run lint-deadcode -- --test
+mise run lint-go -- --fix

--- a/mise-tasks/format
+++ b/mise-tasks/format
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Format the code"
+#MISE sources=["**/*.go", "**/*.json", "**/*.md", "**/*.toml", "**/*.yaml", "**/*.yml"]
+set -e
+golangci-lint fmt ./...
+dprint fmt . --excludes README.md

--- a/mise-tasks/full-check
+++ b/mise-tasks/full-check
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run full pre-commit validation (format, fix, core CI)"
+set -e
+mise run format
+mise run fix
+mise run ci-core

--- a/mise-tasks/lint
+++ b/mise-tasks/lint
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Lint code, check dead code"
+#MISE depends=["lint-mod", "lint-deadcode --test", "lint-go", "lint-release"]
+true

--- a/mise-tasks/lint-deadcode
+++ b/mise-tasks/lint-deadcode
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="Check for dead code"
+#MISE sources=["**/*.go"]
+#USAGE flag "--test" help="Include test files"
+if deadcode ${usage_test:+-test} ./... 2>&1 | grep .; then
+  echo 'dead code found'
+  exit 1
+fi

--- a/mise-tasks/lint-go
+++ b/mise-tasks/lint-go
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Lint Go source"
+#MISE sources=["**/*.go"]
+#USAGE flag "--fix" help="Automatically fix issues"
+golangci-lint run ${usage_fix:+--fix} ./...

--- a/mise-tasks/lint-mod
+++ b/mise-tasks/lint-mod
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Check go.mod tidiness"
+#MISE sources=["go.mod", "**/*.go"]
+go mod tidy -diff

--- a/mise-tasks/lint-release
+++ b/mise-tasks/lint-release
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+#MISE description="Check release config if present"
+test ! -f .goreleaser.yml || goreleaser check

--- a/mise-tasks/test
+++ b/mise-tasks/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Run tests with coverage"
+#MISE sources=["go.mod", "**/*.go"]
+gotestsum -- -race -coverprofile="${COVEROUT}" -covermode=atomic ./...

--- a/mise-tasks/test-int
+++ b/mise-tasks/test-int
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Run integration tests"
+#MISE sources=["go.mod", "**/*.go"]
+gotestsum -- -race -tags=integration ./...

--- a/mise-tasks/tidy
+++ b/mise-tasks/tidy
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+#MISE description="Tidy the module"
+go mod tidy -v

--- a/mise.toml
+++ b/mise.toml
@@ -13,8 +13,9 @@ dprint = "0.54.0"
 ghalint = "1.5.6"
 gitleaks = "8.30.1"
 actionlint = "1.7.12"
-"go:golang.org/x/tools/cmd/deadcode" = "0.46.0"
+copier = "9.16.0"
 "npm:cpd" = "5.0.11"
+"go:golang.org/x/tools/cmd/deadcode" = "0.46.0"
 
 [env]
 COVEROUT = "cover.out"
@@ -22,105 +23,3 @@ HK_PKL_BACKEND = "pklr"
 
 [settings]
 task.timings = false
-
-[tasks."lint:mod"]
-description = "Check go.mod tidiness"
-sources = ["go.mod", "**/*.go"]
-run = "go mod tidy -diff"
-
-[tasks."lint:deadcode"]
-description = "Check for dead code"
-usage = 'flag "--test" help="Include test files"'
-sources = ["**/*.go"]
-run = "deadcode ${usage_test:+-test}  ./... 2>&1 | grep . && { echo 'dead code found'; exit 1; } || true"
-
-[tasks."lint:go"]
-description = "Lint Go source"
-sources = ["**/*.go"]
-usage = 'flag "--fix" help="Automatically fix issues"'
-run = "golangci-lint run ${usage_fix:+--fix} ./..."
-
-[tasks."lint:release"]
-description = "Check release config if present"
-run = "test ! -f .goreleaser.yml || goreleaser check"
-
-[tasks.lint]
-description = "Lint code, check dead code"
-depends = [
-  "lint:mod",
-  { task = "lint:deadcode", args = ["--test"] },
-  "lint:go",
-  "lint:release",
-]
-
-[tasks.fix]
-description = "Lint and fix code"
-run = [
-  "mise run lint:mod",
-  "mise run lint:deadcode -- --test",
-  "mise run lint:go -- --fix",
-]
-
-[tasks.test]
-description = "Run tests with coverage"
-sources = ["go.mod", "**/*.go"]
-run = "gotestsum -- -race -coverprofile=${COVEROUT} -covermode=atomic ./..."
-
-[tasks.test-int]
-description = "Run integration tests"
-sources = ["go.mod", "**/*.go"]
-run = "gotestsum -- -race -tags=integration ./..."
-
-[tasks.coverage]
-description = "Check test coverage"
-depends = ["test"]
-run = "go-test-coverage -config .testcoverage.yml"
-
-[tasks.ci-core]
-description = "Run core CI checks (test, coverage, integration)"
-depends = ["coverage", "test-int"]
-
-[tasks.ci]
-description = "Run full CI pipeline (lint, tests, coverage, build)"
-depends = ["lint", "ci-core", "build"]
-
-[tasks.full-check]
-description = "Run full pre-commit validation (format, fix, core CI)"
-run = [
-  "mise run format",
-  "mise run fix",
-  "mise run ci-core",
-]
-
-[tasks.clean]
-description = "Clean the project"
-run = ["go clean", "rm -f ${COVEROUT}"]
-
-[tasks.format]
-description = "Format the code"
-sources = [
-  "**/*.go",
-  "**/*.json",
-  "**/*.md",
-  "**/*.toml",
-  "**/*.yaml",
-  "**/*.yml",
-]
-run = ["golangci-lint fmt ./...", "dprint fmt . --excludes README.md"]
-
-[tasks.tidy]
-description = "Tidy the module"
-run = "go mod tidy -v"
-
-[tasks.build]
-description = "Build application"
-sources = ["**/*.go", "go.mod", "go.sum"]
-run = "go build -o dist/$(basename $(go list -m)) ."
-
-[tasks.dev]
-description = "Development mode"
-run = "go run ."
-
-[tasks.depup]
-description = "Upgrade dependencies"
-run = ["go get -u -t ./...", "go mod tidy -v"]


### PR DESCRIPTION
Adopts hugoh/go-tools (Copier template) for .golangci.yml,
.testcoverage.yml, cog.toml, codecov.yml, dprint.json, hk.pkl,
.jscpd.json, .markdownlint.json, .renovaterc.json, mise-tasks/ (mise
file tasks), and .github/workflows/{ci,template-update}.yml — these
were previously hand-maintained and duplicated across cellular-signal,
hrd, tmhi-cli, tmhi-gateway, and upd.

mise.toml keeps just [tools]/[env]/[settings] (Renovate's, not
Copier's, from here on — see go-tools' _skip_if_exists). CI now
calls go-tools' reusable workflows by pinned commit SHA, and
template-update.yml keeps this repo in sync via scheduled/dispatched
copier update.
