### PR TITLE
chore: update from go-tools template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 5fa8d23
+_commit: 14d0213
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - internal/version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
     permissions:
       contents: read
     secrets:
@@ -24,7 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   update:
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Manual bootstrap: advances the pinned go-tools SHA to include the template-update race-condition fix. Automated dispatches were stuck on the old (buggy) pinned SHA — this breaks the cycle.