### PR TITLE
chore: update from go-tools template (7e56587)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 14d0213
+_commit: 7e56587
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - internal/version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
     permissions:
       contents: read
     secrets:
@@ -24,7 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   update:
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@14d0213d60106e5368545ecd27a958dc2afa3b8f
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@7e56587. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.