### PR TITLE
fix(cli): replace urfave/cli with stdlib flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli/v3 v3.9.0
 	go.uber.org/goleak v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/urfave/cli/v3 v3.9.0 h1:AV9lIiPv3ukYnxunaCUsHnEozptYmDN2F0+yWqLMn/c=
-github.com/urfave/cli/v3 v3.9.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -6,6 +6,8 @@ package internal
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -15,7 +17,6 @@ import (
 	"github.com/hugoh/upd/internal/logger"
 	"github.com/hugoh/upd/internal/logic"
 	"github.com/hugoh/upd/internal/version"
-	"github.com/urfave/cli/v3"
 )
 
 const (
@@ -35,6 +36,12 @@ const (
 	// ConfigDebug is the debug flag name.
 	ConfigDebug string = "debug"
 )
+
+// Flags holds the parsed command-line flags.
+type Flags struct {
+	ConfigPath string
+	Debug      bool
+}
 
 // SetupLoop initializes the loop with configuration from the given file.
 func SetupLoop(loop *logic.Loop, configPath string) (*config.Configuration, error) {
@@ -60,8 +67,8 @@ func SetupLoop(loop *logic.Loop, configPath string) (*config.Configuration, erro
 }
 
 // Run is the main application entry point handling signals and configuration reload.
-func Run(appCtx context.Context, cmd *cli.Command) error {
-	logger.LogSetup(cmd.Bool(ConfigDebug))
+func Run(appCtx context.Context, flags Flags) error {
+	logger.LogSetup(flags.Debug)
 
 	rootCtx, stopSignalHandlers := signal.NotifyContext(appCtx, syscall.SIGINT, syscall.SIGTERM)
 	defer stopSignalHandlers()
@@ -88,7 +95,7 @@ func Run(appCtx context.Context, cmd *cli.Command) error {
 		go func(ctx context.Context) {
 			defer close(done)
 
-			newConf, err := SetupLoop(loop, cmd.String(ConfigConfig))
+			newConf, err := SetupLoop(loop, flags.ConfigPath)
 			if err != nil {
 				errCh <- fmt.Errorf("cannot configure app: %w", err)
 
@@ -157,34 +164,70 @@ func waitForWorker(
 	}
 }
 
+// ParseFlags parses the given command-line arguments (excluding the program
+// name) into Flags. It returns flag.ErrHelp when --help or --version was
+// requested and already handled, in which case the caller should exit
+// without running the app.
+func ParseFlags(args []string) (Flags, error) {
+	var (
+		flags       Flags
+		showVersion bool
+	)
+
+	flagSet := flag.NewFlagSet(AppName, flag.ContinueOnError)
+	flagSet.Usage = func() {
+		usage := fmt.Sprintf(
+			"%s - %s\n\nUsage:\n  %s [flags]\n\nFlags:\n",
+			AppName,
+			AppShort,
+			AppName,
+		)
+		if _, err := fmt.Fprint(flagSet.Output(), usage); err != nil {
+			return
+		}
+
+		flagSet.PrintDefaults()
+	}
+
+	flagSet.StringVar(
+		&flags.ConfigPath,
+		ConfigConfig,
+		config.DefaultConfig,
+		"use the specified TOML configuration file",
+	)
+	flagSet.StringVar(&flags.ConfigPath, "c", config.DefaultConfig, "shorthand for --"+ConfigConfig)
+	flagSet.BoolVar(&flags.Debug, ConfigDebug, false, "display debugging output in the console")
+	flagSet.BoolVar(&flags.Debug, "d", false, "shorthand for --"+ConfigDebug)
+	flagSet.BoolVar(&showVersion, "version", false, "print the version and exit")
+
+	if err := flagSet.Parse(args); err != nil {
+		return Flags{}, fmt.Errorf("failed to parse flags: %w", err)
+	}
+
+	if showVersion {
+		versionLine := fmt.Sprintf("%s version %s\n", AppName, version.Version())
+		if _, err := fmt.Fprint(os.Stdout, versionLine); err != nil {
+			return Flags{}, fmt.Errorf("failed to print version: %w", err)
+		}
+
+		return Flags{}, flag.ErrHelp
+	}
+
+	return flags, nil
+}
+
 // Cmd creates and runs the CLI application.
 func Cmd() error {
-	flags := []cli.Flag{
-		&cli.StringFlag{
-			Name:      ConfigConfig,
-			Aliases:   []string{"c"},
-			Usage:     "use the specified TOML configuration file",
-			Value:     config.DefaultConfig,
-			TakesFile: true,
-		},
-		&cli.BoolFlag{
-			Name:    ConfigDebug,
-			Aliases: []string{"d"},
-			Value:   false,
-			Usage:   "display debugging output in the console",
-		},
-	}
-
-	app := &cli.Command{
-		Name:    AppName,
-		Usage:   AppShort,
-		Version: version.Version(),
-		Flags:   flags,
-		Action:  Run,
-	}
-
-	err := app.Run(context.Background(), os.Args)
+	flags, err := ParseFlags(os.Args[1:])
 	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+
+		return err
+	}
+
+	if err := Run(context.Background(), flags); err != nil {
 		return fmt.Errorf("failed to run app: %w", err)
 	}
 

--- a/internal/cmd_test.go
+++ b/internal/cmd_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hugoh/upd/internal/logic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli/v3"
 )
 
 // Must match internal/config/config_test.go.
@@ -22,16 +21,8 @@ func TestRun_NoMultipleRestartsOnSuccess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 	defer cancel()
 
-	cmd := &cli.Command{
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  ConfigConfig,
-				Value: testConfigDir + "/upd_test_minimal.toml",
-			},
-			&cli.BoolFlag{
-				Name: ConfigDebug,
-			},
-		},
+	cmd := Flags{
+		ConfigPath: testConfigDir + "/upd_test_minimal.toml",
 	}
 
 	startTime := time.Now()
@@ -44,16 +35,8 @@ func TestRun_NoMultipleRestartsOnSuccess(t *testing.T) {
 func TestRun_WaitsForWorkerCompletion(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
-	cmd := &cli.Command{
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  ConfigConfig,
-				Value: testConfigDir + "/upd_test_minimal.toml",
-			},
-			&cli.BoolFlag{
-				Name: ConfigDebug,
-			},
-		},
+	cmd := Flags{
+		ConfigPath: testConfigDir + "/upd_test_minimal.toml",
 	}
 
 	done := make(chan struct{})
@@ -87,16 +70,8 @@ func TestRun_SighupReloadsConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	cmd := &cli.Command{
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  ConfigConfig,
-				Value: cfgPath,
-			},
-			&cli.BoolFlag{
-				Name: ConfigDebug,
-			},
-		},
+	cmd := Flags{
+		ConfigPath: cfgPath,
 	}
 
 	errResult := make(chan error, 1)


### PR DESCRIPTION
Single command, two flags — no need for a full CLI framework.
