### PR TITLE
chore: pre-seed renamed copier answer keys for go-tools template migration

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -4,8 +4,8 @@ _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - internal/version
 codecov_style: simple
-cog_omit_type: lint
-coverage_backends_override: false
+cog_omit_types:
+- lint
 coverage_total: 80
 dev_watch: false
 dprint_has_excludes: true
@@ -35,4 +35,5 @@ project_description: Tool to monitor if the network connection is up
 project_name: upd
 test_int_cmd: gotestsum -- -race -tags=integration ./...
 testcoverage_excludes: []
+testcoverage_overrides: []
 


### PR DESCRIPTION
cog_omit_type -> cog_omit_types, coverage_backends_override -> testcoverage_overrides.
Prevents the automated go-tools template-update workflow from silently
resetting these to defaults via 'copier update --defaults' once the
template rename lands.
