### PR TITLE
chore: update from go-tools template (bc7c629)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: b341f90
+_commit: bc7c629
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - internal/version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@bc7c629e60bd78a6b10749054c481382cffedacf
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@bc7c629e60bd78a6b10749054c481382cffedacf
     permissions:
       contents: read
     secrets:
@@ -24,7 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@bc7c629e60bd78a6b10749054c481382cffedacf
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   update:
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@bc7c629e60bd78a6b10749054c481382cffedacf
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@bc7c629. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.