### PR TITLE
chore: update from go-tools template (v1.0.0)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -36,4 +36,3 @@ project_name: upd
 test_int_cmd: gotestsum -- -race -tags=integration ./...
 testcoverage_excludes: []
 testcoverage_overrides: []
-

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: bc7c629
+_commit: v1.0.0
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - internal/version
@@ -36,3 +36,4 @@ project_name: upd
 test_int_cmd: gotestsum -- -race -tags=integration ./...
 testcoverage_excludes: []
 testcoverage_overrides: []
+


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@v1.0.0. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.