### PR TITLE
chore: update from go-tools template (v1.0.0)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -36,3 +36,4 @@ project_name: upd
 test_int_cmd: gotestsum -- -race -tags=integration ./...
 testcoverage_excludes: []
 testcoverage_overrides: []
+


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@v1.0.0. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.