### PR TITLE
fix(hk): exclude hugoh/go-tools pins from pinact's comment management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b # v1.1.0
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b # v1.1.0
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
     permissions:
       contents: read
     secrets:
@@ -24,7 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b # v1.1.0
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   update:
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b # v1.1.0
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
     permissions:
       contents: write
       pull-requests: write

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,7 +4,15 @@ import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtin
 local Common = new Group {
   steps {
     ["actionlint"] = Builtins.actionlint
-    ["pinact"] = Builtins.pinact
+    // hugoh/go-tools' own self-referential workflow pins are rendered by the
+    // go-tools template using the raw commit hash with no version comment;
+    // excluding them from pinact keeps that comment-less form stable so
+    // copier update's 3-way merge never has to reconcile a pinact-added
+    // comment against the template's un-commented rendering
+    ["pinact"] = (Builtins.pinact) {
+      check_diff = "pinact run --verify --check --exclude 'hugoh/go-tools.*' {{ files }}"
+      fix = "pinact run --verify --exclude 'hugoh/go-tools.*' {{ files }}"
+    }
     ["conflicts"] = Builtins.check_merge_conflict
     ["trailing-ws"] = Builtins.trailing_whitespace
     ["line-endings"] = Builtins.mixed_line_ending


### PR DESCRIPTION
Strip the `# vX.Y.Z` comment pinact previously added to the self-referential `hugoh/go-tools` workflow pins, and exclude them from pinact going forward. The go-tools template renders these pins as a raw commit hash with no comment, so a locally-added comment causes `copier update`'s 3-way merge to conflict on that line every go-tools release. Companion fix: [hugoh/go-tools@v1.1.1](https://github.com/hugoh/go-tools/releases/tag/v1.1.1).