### PR TITLE
chore: update from go-tools template (v1.1.1)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v1.0.0
+_commit: v1.1.1
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - internal/version
@@ -36,3 +36,4 @@ project_name: upd
 test_int_cmd: gotestsum -- -race -tags=integration ./...
 testcoverage_excludes: []
 testcoverage_overrides: []
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,20 @@ permissions: {}
 
 jobs:
   hk:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-hk.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+=======
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@fd312307bff06315fdff0d57fa5fa878d250f5c1
+>>>>>>> after updating
     permissions:
       contents: read
 
   goci:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-ci.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+=======
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@fd312307bff06315fdff0d57fa5fa878d250f5c1
+>>>>>>> after updating
     permissions:
       contents: read
     secrets:
@@ -24,7 +32,11 @@ jobs:
 
   release:
     needs: [hk, goci]
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-release.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+=======
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@fd312307bff06315fdff0d57fa5fa878d250f5c1
+>>>>>>> after updating
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -2,17 +2,20 @@
 name: Update from go-tools template
 
 on:
-  schedule:
-    - cron: "0 6 * * 1"
-  repository_dispatch:
-    types: [go-tools-updated]
+  push:
+    branches:
+      - renovate/**
   workflow_dispatch: {}
 
 permissions: {}
 
 jobs:
   update:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-template-update.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+=======
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@fd312307bff06315fdff0d57fa5fa878d250f5c1
+>>>>>>> after updating
     permissions:
       contents: write
       pull-requests: write

--- a/hk.pkl
+++ b/hk.pkl
@@ -4,11 +4,19 @@ import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtin
 local Common = new Group {
   steps {
     ["actionlint"] = Builtins.actionlint
+<<<<<<< before updating
     // hugoh/go-tools' own self-referential workflow pins are rendered by the
     // go-tools template using the raw commit hash with no version comment;
     // excluding them from pinact keeps that comment-less form stable so
     // copier update's 3-way merge never has to reconcile a pinact-added
     // comment against the template's un-commented rendering
+=======
+    // hugoh/go-tools' own self-referential workflow pins are rendered by this
+    // template using the raw commit hash with no version comment; excluding
+    // them from pinact keeps that comment-less form stable so copier update's
+    // 3-way merge never has to reconcile a pinact-added comment against the
+    // template's un-commented rendering
+>>>>>>> after updating
     ["pinact"] = (Builtins.pinact) {
       check_diff = "pinact run --verify --check --exclude 'hugoh/go-tools.*' {{ files }}"
       fix = "pinact run --verify --exclude 'hugoh/go-tools.*' {{ files }}"
@@ -36,7 +44,13 @@ local linters = new Mapping<String, Step> {
   ["golangci-lint"] = (Builtins.golangci_lint) {
     profiles = List("!ci")
   }
+<<<<<<< before updating
   ["gomod-tidy"] = Builtins.gomod_tidy
+=======
+  ["gomod-tidy"] = (Builtins.gomod_tidy) {
+    profiles = List("!ci")
+  }
+>>>>>>> after updating
   ["shellcheck"] = Builtins.shellcheck
   ["conventional-commit"] {
     check = "cog check --from-latest-tag"


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@v1.1.1. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.