### PR TITLE
chore: adopt hk-config shell group via copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v1.5.2
+_commit: v1.9.0
 _src_path: https://github.com/hugoh/go-tools.git
 codecov_ignore:
 - internal/version
@@ -7,7 +7,6 @@ codecov_style: simple
 cog_omit_types:
 - lint
 coverage_total: 80
-dev_watch: false
 golangci_extra_disable:
 - depguard
 - exhaustruct
@@ -21,6 +20,7 @@ golangci_test_exclude_linters:
 - varnamelen
 goreleaser_before_hooks: []
 goreleaser_version_pkg: github.com/hugoh/upd/internal/version
+has_executable: true
 has_fuzz: false
 has_gen: false
 has_goreleaser: true
@@ -36,5 +36,3 @@ test_int_cmd: gotestsum -- -race -tags=integration ./...
 testcoverage_excludes: []
 testcoverage_overrides: []
 
-
-#copier updated

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,24 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        type: choice
+        description: "Version bump type"
+        default: auto
+        options: [auto, patch, minor, major]
 
 permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@6f474d4b70ee5897a1bf3c250331ea680f85788a
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@a88141d2e3c0572f37476995792146b37c268005
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@6f474d4b70ee5897a1bf3c250331ea680f85788a
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@a88141d2e3c0572f37476995792146b37c268005
     permissions:
       contents: read
     secrets:
@@ -24,9 +31,11 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@6f474d4b70ee5897a1bf3c250331ea680f85788a
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@a88141d2e3c0572f37476995792146b37c268005
     permissions:
       contents: write
+    with:
+      bump_type: ${{ inputs.bump_type || 'auto' }}
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
       tap_github_token: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,14 +1,15 @@
 amends "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.50.0/hk@1.50.0#/Builtins.pkl"
-import "package://github.com/hugoh/hk-config/releases/download/v0.2.1/hk-config@0.2.1#/base.pkl" as Base
+import "package://github.com/hugoh/hk-config/releases/download/v0.3.0/hk-config@0.3.0#/base.pkl" as Base
 
 min_hk_version = Base.min_hk_version
 
 local linters = new Mapping<String, Step> {
   ...Base.base
-  ["shellcheck"] = Builtins.shellcheck
-  ["shellharden"] = Builtins.shellharden
-  ["trailing-ws"] = (Base.base["trailing-ws"]) {
+  ...Base.shell
+  // go generate output can legitimately end without touching trailing
+  // whitespace elsewhere in the file; base's check conflicts with that
+  ["trailing-ws"] = (Builtins.trailing_whitespace) {
     condition = "false"
   }
   // hugoh/go-tools' own self-referential workflow pins are rendered by this
@@ -27,6 +28,11 @@ local linters = new Mapping<String, Step> {
   ["newlines"] = (Builtins.newlines) {
     exclude = List(".copier-answers.yml")
   }
+  // Same copier-serializer quirk as above: it omits the trailing newline
+  // ryl's new-line-at-end-of-file rule expects
+  ["yaml"] = (Builtins.ryl) {
+    exclude = List(".copier-answers.yml")
+  }
   ["golangci-lint-config"] = {
     check = "golangci-lint config verify"
   }
@@ -36,7 +42,6 @@ local linters = new Mapping<String, Step> {
   ["gomod-tidy"] = (Builtins.gomod_tidy) {
     profiles = List("!ci")
   }
-  ["shellcheck"] = Builtins.shellcheck
   ["conventional-commit"] {
     check = "cog check --from-latest-tag"
   }

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,10 @@ copier = "9.16.0"
 "npm:cpd" = "5.0.11"
 "go:golang.org/x/tools/cmd/deadcode" = "0.46.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "1.1.4"
+"github:anordal/shellharden" = "4.3.2"
+"github:owenlamont/ryl" = "0.21.0"
+shfmt = "3.13.1"
+tombi = "1.1.6"
 
 [env]
 COVEROUT = "cover.out"


### PR DESCRIPTION
Real `copier update --trust --defaults` run (not a hand-edit) now that go-tools' template imports hk-config's `Base` directly. Resolves the expected 3-way merge conflict in `hk.pkl` (old hand-rolled `Common` group vs new `Base.shell` adoption), fixing a duplicate `shellcheck` key along the way. Picks up `shfmt`/`tombi`/`ryl` as new checks. Adds `.yamllint` so `ryl` has a config to load.

Part of a fleet-wide hk-config v0.3 rollout.